### PR TITLE
Use UUIDs as primary keys - not integers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,6 @@ module Bookyourplace
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-
     config.generators do |g|
       g.assets           false
       g.channel          assets: false
@@ -34,6 +33,7 @@ module Bookyourplace
       g.helper           false
       g.helper_specs     false
       g.javascripts      false
+      g.orm              :active_record, primary_key_type: :uuid
       g.stylesheets      false
       g.system_tests     nil
       g.routing_specs    false

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,3 @@
+Rails.application.config.generators do |g|
+  g.orm :active_record, primary_key_type: :uuid
+end

--- a/db/migrate/20180830184024_enable_pgcrypto_extension.rb
+++ b/db/migrate/20180830184024_enable_pgcrypto_extension.rb
@@ -1,0 +1,5 @@
+class EnablePgcryptoExtension < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,19 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2018_08_30_184024) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
+  enable_extension "plpgsql"
+
+end


### PR DESCRIPTION
#### What's this PR do?
Sets up the app to use UUIDS, not integers, as primary keys for all tables.

##### Background context
Using UUIDs, rather than integers, as primary keys offers a number of security, and other, advantages.

#### Migrations
Yes, one. Will need to run:

`rails db:migrate`
