### PR TITLE
Use factory_bot_rails not factory_girl for test factories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'webpacker'
 
 group :development, :test do
   gem 'coveralls', require: false
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'pry'
   gem 'pry-byebug'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,10 +62,10 @@ GEM
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
-    factory_girl (4.9.0)
+    factory_bot (4.11.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.11.0)
+      factory_bot (~> 4.11.0)
       railties (>= 3.0.0)
     ffi (1.9.25)
     globalid (0.4.1)
@@ -211,7 +211,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   coveralls
-  factory_girl_rails
+  factory_bot_rails
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry


### PR DESCRIPTION
#### What's this PR do?
Installs factory_bot_rails gem and removes factory_girl (for test factories)

##### Background context
factory_girl gem is deprecated

#### Additional deployment instructions
Will need to run:
`bundle`
