### PR TITLE
Add User, Guide and Guest models

### DIFF
--- a/app/models/users/guest.rb
+++ b/app/models/users/guest.rb
@@ -1,0 +1,3 @@
+# Represents users who go on trips
+class Guest < User
+end

--- a/app/models/users/guide.rb
+++ b/app/models/users/guide.rb
@@ -1,0 +1,3 @@
+# Represents users who host trips
+class Guide < User
+end

--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -1,0 +1,8 @@
+# Super class for all users: guests, guides.
+class User < ApplicationRecord
+  validates :email, format: /\A\w+@\w+\.{1}[a-zA-Z]{2,}\z/, presence: true, uniqueness: true
+  validates :name, format: /\A[\sa-zA-Z0-9_.\-]+\z/, allow_blank: true
+  validates :phone_number, format: /\A[0-9+.x()\-]{7,}\z/, allow_blank: true
+  validates :type, inclusion: { in: %w(Guide Guest),
+    message: "%{value} is not a valid type of user" }, presence: true
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,7 @@ module Bookyourplace
       g.test_framework   false
       g.view_specs       false
     end
+
+    config.autoload_paths += %W(#{config.root}/app/models/users)
   end
 end

--- a/db/migrate/20180902141601_create_users.rb
+++ b/db/migrate/20180902141601_create_users.rb
@@ -1,0 +1,13 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users, id: :uuid do |t|
+      t.string :type
+      t.string :name
+      t.string :email, index: true
+      t.string :phone_number
+      t.text :address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_30_184024) do
+ActiveRecord::Schema.define(version: 2018_09_02_141601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "type"
+    t.string "name"
+    t.string "email"
+    t.string "phone_number"
+    t.text "address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email"
+  end
 
 end

--- a/spec/factories/users/guest.rb
+++ b/spec/factories/users/guest.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :guest, parent: :user, class: 'Guest' do
+    address Faker::Address.full_address
+    email Faker::Internet.email
+    name Faker::Name.name
+    phone_number Faker::PhoneNumber.cell_phone
+    type 'Guest'
+  end
+end

--- a/spec/factories/users/guide.rb
+++ b/spec/factories/users/guide.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :guide, parent: :user, class: 'Guide' do
+    address Faker::Address.full_address
+    email Faker::Internet.email
+    name Faker::Name.name
+    phone_number Faker::PhoneNumber.cell_phone
+    type 'Guide'
+  end
+end

--- a/spec/factories/users/user.rb
+++ b/spec/factories/users/user.rb
@@ -1,0 +1,11 @@
+require 'faker'
+
+FactoryBot.define do
+  factory :user do
+    address Faker::Address.full_address
+    email Faker::Internet.email
+    name Faker::Name.name
+    phone_number Faker::PhoneNumber.cell_phone
+    type %w(Guest Guide).sample
+  end
+end

--- a/spec/models/users/guest_spec.rb
+++ b/spec/models/users/guest_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Guest, type: :model do
+  describe 'associations' do
+    context 'inheritance' do
+      subject { Guest.superclass }
+      it { should eq(User) }
+    end
+  end
+  describe 'validations' do
+    context 'type' do
+      subject { FactoryBot.build(:guest).type }
+      it { should eq('Guest') }
+    end
+  end
+end

--- a/spec/models/users/guide_spec.rb
+++ b/spec/models/users/guide_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Guide, type: :model do
+  describe 'associations' do
+    context 'inheritance' do
+      subject { Guide.superclass }
+      it { should eq(User) }
+    end
+  end
+  describe 'validations' do
+    context 'type' do
+      subject { FactoryBot.build(:guide).type }
+      it { should eq('Guide') }
+    end
+  end
+end

--- a/spec/models/users/user_spec.rb
+++ b/spec/models/users/user_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe User, type: :model do
+  context 'associations' do
+  end
+  context 'validations' do
+    context 'email' do
+      it { should allow_value(Faker::Internet.email).for(:email) }
+      it { should_not allow_values(Faker::Lorem.word, Faker::PhoneNumber.cell_phone ).for(:email) }
+      it { should validate_presence_of(:email) }
+      it { should validate_uniqueness_of(:email) }
+    end
+    context 'name' do
+      it { should_not allow_value('<SQL INJECTION>').for(:name) }
+      it { should allow_value(Faker::Lorem.word).for(:name) }
+    end
+    context 'phone_number' do
+      it { should allow_value(Faker::PhoneNumber.cell_phone).for(:phone_number) }
+      it { should_not allow_value(Faker::Lorem.word).for(:email) }
+    end
+    context 'type' do
+      it { should allow_values('Guide', 'Guest').for(:type) }
+      it { should_not allow_values(Faker::Lorem.word).for(:type) }
+      it { should validate_presence_of(:type) }
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
Adds the first models of the app: User, Guide, Guest models.

##### Background context
Part of this work #7 - building out the models of the [ERD](https://docs.google.com/presentation/d/1Xilql2vzIe8jNsuiGR6r1aN5_45nUQpMgRAUIAXAMqU/edit?usp=sharing).
After some deliberation, I decided that there should be a User superclass which then has two child classes: Guest and Guide. Guest and Guides both share lots of behaviour, so it makes sense to extract that shared behaviour out into a parent class.
I also decided to rename TripProvider -> Guide. There would of be some strange join models later eg: trip_providers_trips, etc. So trying to reduce the names using "trip" in them. 
Guest and guide also seems more pleasing than guest and trip_provider.

Really, User is an abstract class, but to have the shared validations remain in User, not duplicated in its child classes, I didn't raise an exception in the User#initialize method.

#### Where should the reviewer start?
models/users

#### How should this be manually tested?
Not hooked up yet.

#### Migrations
Yes, one, will need to run:
`rails db:migrate`
