### PR TITLE
Add trip model

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,0 +1,20 @@
+class Trip < ApplicationRecord
+  validate :start_date_before_end_date
+  validates :name, format: /\A[\sa-zA-Z0-9_.\-]+\z/, presence: true # TODO: make this unique within an organisation's scope
+  validates :minimum_number_of_guests, numericality: { only_integer: true }, allow_nil: true
+  validates :maximum_number_of_guests, numericality: { only_integer: true }, allow_nil: true
+
+  has_and_belongs_to_many :guests, association_foreign_key: 'user_id'
+  has_and_belongs_to_many :guides, association_foreign_key: 'user_id'
+ 
+  def valid_date_format
+    # TODO: implement when we know the format of the date string we are receiving
+  end
+
+  def start_date_before_end_date
+    return if start_date.nil? && end_date.nil?
+    return if start_date <= end_date
+
+    errors.add(:base, :start_date_after_end_date, message: 'start date must be before end date')
+  end
+end

--- a/app/models/users/guest.rb
+++ b/app/models/users/guest.rb
@@ -1,3 +1,4 @@
 # Represents users who go on trips
 class Guest < User
+  has_and_belongs_to_many :trips, foreign_key: 'user_id'
 end

--- a/app/models/users/guide.rb
+++ b/app/models/users/guide.rb
@@ -1,3 +1,4 @@
 # Represents users who host trips
 class Guide < User
+  has_and_belongs_to_many :trips, foreign_key: 'user_id'
 end

--- a/db/migrate/20180903131414_create_trips.rb
+++ b/db/migrate/20180903131414_create_trips.rb
@@ -1,0 +1,18 @@
+class CreateTrips < ActiveRecord::Migration[5.2]
+  def change
+    create_table :trips, id: :uuid do |t|
+      t.string :name
+      t.datetime :start_date
+      t.datetime :end_date
+      t.integer :minimum_number_of_guests
+      t.integer :maximum_number_of_guests
+
+      t.uuid :created_by_id
+      t.uuid :updated_by_id
+
+      t.timestamps
+    end
+    add_foreign_key :trips, :users, column: :created_by_id, primary_key: :id
+    add_foreign_key :trips, :users, column: :updated_by_id, primary_key: :id
+  end
+end

--- a/db/migrate/20180903131951_create_join_table_users_trips.rb
+++ b/db/migrate/20180903131951_create_join_table_users_trips.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableUsersTrips < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :users, :trips, column_options: { type: :uuid } do |t|
+      t.index [:user_id, :trip_id], :unique => true
+      t.index :trip_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_02_141601) do
+ActiveRecord::Schema.define(version: 2018_09_03_131951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "trips", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.integer "minimum_number_of_guests"
+    t.integer "maximum_number_of_guests"
+    t.uuid "created_by_id"
+    t.uuid "updated_by_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "trips_users", id: false, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "trip_id", null: false
+    t.index ["trip_id"], name: "index_trips_users_on_trip_id"
+    t.index ["user_id", "trip_id"], name: "index_trips_users_on_user_id_and_trip_id", unique: true
+  end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "type"
@@ -27,4 +46,6 @@ ActiveRecord::Schema.define(version: 2018_09_02_141601) do
     t.index ["email"], name: "index_users_on_email"
   end
 
+  add_foreign_key "trips", "users", column: "created_by_id"
+  add_foreign_key "trips", "users", column: "updated_by_id"
 end

--- a/spec/factories/trip.rb
+++ b/spec/factories/trip.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :trip do
+    name Faker::Name.name
+  end
+end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Trip, type: :model do
+  describe 'associations' do
+    it { is_expected.to have_and_belong_to_many(:guests) }
+    it { is_expected.to have_and_belong_to_many(:guides) }
+  end
+
+  describe 'validations' do
+    describe 'name' do
+      it { should_not allow_value('<SQL INJECTION>').for(:name) }
+      it { should allow_value(Faker::Lorem.word).for(:name) }
+      # TODO: check uniqueness to organisation scope
+    end
+
+    describe 'minimum_number_of_guests' do
+      it { should validate_numericality_of(:minimum_number_of_guests).only_integer }
+    end
+
+    describe 'maximum_number_of_guests' do
+      it { should validate_numericality_of(:maximum_number_of_guests).only_integer }
+    end
+
+    # TODO: when know format of date string we're sending back and also test that
+    describe 'dates' do
+      subject { trip.valid? }
+
+      let(:trip) { FactoryBot.build(:trip, start_date: start_date, end_date: end_date) }
+
+      context 'valid' do
+        context 'start_date is before end_date' do
+          let(:start_date) { Date.today }
+          let(:end_date) { Faker::Date.between(2.days.from_now, 10.days.from_now) }
+
+          it { should be true }
+        end
+      end
+
+      context 'invalid' do
+        context 'start_date is after end_date' do
+          let(:start_date) { Faker::Date.between(2.days.from_now, 10.days.from_now) }
+          let(:end_date) { Date.today }
+
+          it { should be false }
+        end
+      end
+    end
+  end
+end

--- a/spec/models/users/guest_spec.rb
+++ b/spec/models/users/guest_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Guest, type: :model do
   describe 'associations' do
+    it { is_expected.to have_and_belong_to_many(:trips) }
+
     context 'inheritance' do
       subject { Guest.superclass }
       it { should eq(User) }

--- a/spec/models/users/guide_spec.rb
+++ b/spec/models/users/guide_spec.rb
@@ -2,11 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Guide, type: :model do
   describe 'associations' do
+    it { is_expected.to have_and_belong_to_many(:trips) }
+
     context 'inheritance' do
       subject { Guide.superclass }
       it { should eq(User) }
     end
   end
+
   describe 'validations' do
     context 'type' do
       subject { FactoryBot.build(:guide).type }


### PR DESCRIPTION
#### What's this PR do?
Adds Trip model and users_trips join table, to associate users with trips.

##### Background context
A trip can have many users (both guides and guests)
A user (both guides and guests) can have many trips.
This is a many-to-many relationship, implemented in Rails using a join table and the has_and_belongs_to_many macro. (ref:  [The has_and_belongs_to_many Association](https://guides.rubyonrails.org/association_basics.html#the-has-and-belongs-to-many-association) )

#### Where should the reviewer start?
app/models/trip.rb and spec/models/trip_spec.rb

#### How should this be manually tested?
Not plumbed in yet.

#### Migrations
Yes, 1. Please run:
`rails db:migrate`
