### PR TITLE
Fix users name and phone_number regex

### DIFF
--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -1,8 +1,9 @@
 # Super class for all users: guests, guides.
 class User < ApplicationRecord
   validates :email, format: /\A\w+@\w+\.{1}[a-zA-Z]{2,}\z/, presence: true, uniqueness: true
-  validates :name, format: /\A[\sa-zA-Z0-9_.\-]+\z/, allow_blank: true
-  validates :phone_number, format: /\A[0-9+.x()\-]{7,}\z/, allow_blank: true
+  validates :name, format: /\A[\sa-zA-Z0-9_.'\-]+\z/, allow_blank: true
+  validates :phone_number, format: /\A[0-9+.x()\-\s]{7,}\z/, allow_blank: true
   validates :type, inclusion: { in: %w(Guide Guest),
     message: "%{value} is not a valid type of user" }, presence: true
+
 end


### PR DESCRIPTION
#### What's this PR do?
Fixes two issues with users' regex, that was found by intermittently failing specs:
1) Users' name would be invalid if they had an apostrophe in it, ex: James O'Daley
2) Users' phone_number would be invalid if there was whitespace in it, ex: (0208) 208 4576


