### PR TITLE
Fix FactoryBot deprecation warnings

### DIFF
--- a/spec/factories/trip.rb
+++ b/spec/factories/trip.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :trip do
-    name Faker::Name.name
+    name { Faker::Name.name }
   end
 end

--- a/spec/factories/users/guest.rb
+++ b/spec/factories/users/guest.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :guest, parent: :user, class: 'Guest' do
-    address Faker::Address.full_address
-    email Faker::Internet.email
-    name Faker::Name.name
-    phone_number Faker::PhoneNumber.cell_phone
-    type 'Guest'
+    address { Faker::Address.full_address }
+    email { Faker::Internet.email }
+    name { Faker::Name.name }
+    phone_number { Faker::PhoneNumber.cell_phone }
+    type { 'Guest' }
   end
 end

--- a/spec/factories/users/guide.rb
+++ b/spec/factories/users/guide.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :guide, parent: :user, class: 'Guide' do
-    address Faker::Address.full_address
-    email Faker::Internet.email
-    name Faker::Name.name
-    phone_number Faker::PhoneNumber.cell_phone
-    type 'Guide'
+    address { Faker::Address.full_address }
+    email { Faker::Internet.email }
+    name { Faker::Name.name }
+    phone_number { Faker::PhoneNumber.cell_phone }
+    type { 'Guide' }
   end
 end

--- a/spec/factories/users/user.rb
+++ b/spec/factories/users/user.rb
@@ -2,10 +2,10 @@ require 'faker'
 
 FactoryBot.define do
   factory :user do
-    address Faker::Address.full_address
-    email Faker::Internet.email
-    name Faker::Name.name
-    phone_number Faker::PhoneNumber.cell_phone
-    type %w(Guest Guide).sample
+    address { Faker::Address.full_address }
+    email { Faker::Internet.email }
+    name { Faker::Name.name }
+    phone_number { Faker::PhoneNumber.cell_phone }
+    type { %w(Guest Guide).sample }
   end
 end


### PR DESCRIPTION
#### What's this PR do?
Fixes the deprecation warnings from FactoryBot, the library we use to create factories of models using in the test suite.

##### Background context
Running the test suite produced some very verbose deprecation warnings, ex:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

type { "Guest" }
```



