### PR TITLE
Add created_by_id and updated_by_id to users and trips_users.

### DIFF
--- a/db/migrate/20180925054113_add_created_by_update_by_to_models.rb
+++ b/db/migrate/20180925054113_add_created_by_update_by_to_models.rb
@@ -1,0 +1,11 @@
+class AddCreatedByUpdateByToModels < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :created_by_id, :uuid
+    add_column :users, :updated_by_id, :uuid
+    add_column :trips_users, :created_by_id, :uuid
+    add_column :trips_users, :updated_by_id, :uuid
+
+    add_foreign_key :trips_users, :users, column: :created_by_id, primary_key: :id
+    add_foreign_key :trips_users, :users, column: :updated_by_id, primary_key: :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_03_131951) do
+ActiveRecord::Schema.define(version: 2018_09_25_054113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -31,6 +31,8 @@ ActiveRecord::Schema.define(version: 2018_09_03_131951) do
   create_table "trips_users", id: false, force: :cascade do |t|
     t.uuid "user_id", null: false
     t.uuid "trip_id", null: false
+    t.uuid "created_by_id"
+    t.uuid "updated_by_id"
     t.index ["trip_id"], name: "index_trips_users_on_trip_id"
     t.index ["user_id", "trip_id"], name: "index_trips_users_on_user_id_and_trip_id", unique: true
   end
@@ -43,9 +45,13 @@ ActiveRecord::Schema.define(version: 2018_09_03_131951) do
     t.text "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "created_by_id"
+    t.uuid "updated_by_id"
     t.index ["email"], name: "index_users_on_email"
   end
 
   add_foreign_key "trips", "users", column: "created_by_id"
   add_foreign_key "trips", "users", column: "updated_by_id"
+  add_foreign_key "trips_users", "users", column: "created_by_id"
+  add_foreign_key "trips_users", "users", column: "updated_by_id"
 end


### PR DESCRIPTION
#### What's this PR do?
Add created_by_id and updated_by_id to users and trips_users.
This is now consistent with our trip table.

##### Background context
We will want to record which user created or updated:
A user (both guides and guests);
A trip (already has these fields);
And a trips_user (the join between a trip and a user).

This is to cover the situation where there is a query regarding
who changed what data on a trip, user, or who added a user to a trip, etc.

Subsequent work will investigate using Rails' CurrentAttributes or just
Devise style current_user, and also add Devive authentication library.
Then we will have the concept of a current user in the app, which we can
use to update these fields (using a model concern, mixed in to all these three models).

Refs:
https://github.com/Book-Your-Place/bookyourplace/issues/19
https://github.com/Book-Your-Place/bookyourplace/issues/20


#### Migrations
Yes - one.
Will need to run:

`rails db:migrate
`
to get app working.


