### PR TITLE
Add Devise to Users / Authenticate all routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
+  devise_group :user, contains: [:guest, :guide]
 end

--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -6,4 +6,6 @@ class User < ApplicationRecord
   validates :type, inclusion: { in: %w(Guide Guest),
     message: "%{value} is not a valid type of user" }, presence: true
 
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'trips#index'
 
+  devise_for :guests
+  devise_for :guides
+
   resources :trips
   resources :guests, only: %i(create edit index new show update)
 end

--- a/db/migrate/20180928164324_add_devise_to_users.rb
+++ b/db/migrate/20180928164324_add_devise_to_users.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class AddDeviseToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_table :users, id: :uuid do |t|
+      ## Database authenticatable
+
+      # My override to deal with user table already exisiting
+      # t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet     :current_sign_in_ip
+      t.inet     :last_sign_in_ip
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      # My override to deal with user table already exisiting
+      # t.timestamps null: false
+    end
+
+    # My override to deal with user table already exisiting
+    change_column_default(:users, :email, "")
+    change_column :users, :email, :string, null: false
+
+    # My override to deal with user table already exisiting
+    # add_index :users, :email,                unique: true
+    remove_index :users, :email
+    add_index :users, :email, unique: true
+
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_25_054113) do
+ActiveRecord::Schema.define(version: 2018_09_28_164324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -40,14 +40,29 @@ ActiveRecord::Schema.define(version: 2018_09_25_054113) do
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "type"
     t.string "name"
-    t.string "email"
+    t.string "email", default: "", null: false
     t.string "phone_number"
     t.text "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "created_by_id"
     t.uuid "updated_by_id"
-    t.index ["email"], name: "index_users_on_email"
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "trips", "users", column: "created_by_id"

--- a/spec/factories/users/user.rb
+++ b/spec/factories/users/user.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     address { Faker::Address.full_address }
     email { Faker::Internet.email }
     name { Faker::Name.name }
+    password { Faker::Internet.password }
     phone_number { Faker::PhoneNumber.cell_phone }
     type { %w(Guest Guide).sample }
   end

--- a/spec/models/users/user_spec.rb
+++ b/spec/models/users/user_spec.rb
@@ -8,7 +8,7 @@ describe User, type: :model do
       it { should allow_value(Faker::Internet.email).for(:email) }
       it { should_not allow_values(Faker::Lorem.word, Faker::PhoneNumber.cell_phone ).for(:email) }
       it { should validate_presence_of(:email) }
-      it { should validate_uniqueness_of(:email) }
+      it { should validate_uniqueness_of(:email).ignoring_case_sensitivity }
     end
     context 'name' do
       it { should_not allow_value('<SQL INJECTION>').for(:name) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,6 +58,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/guests_controller_spec.rb
+++ b/spec/requests/guests_controller_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'GuestsController', type: :request do
       end
 
       it 'should create a new guest' do
+        pending 'Need to think about how guests are created: when they sign up to a trip, and when a guide adds them to a trip, etc'
         expect { do_request(params: params) }.to change { Guest.count }.by(1)
 
         expect(response.code).to eq '302'
@@ -72,6 +73,7 @@ RSpec.describe 'GuestsController', type: :request do
     
     context 'valid and successful' do
       it 'should successfully render' do
+        pending 'Need to make sure that only a signed in user can edit their OWN details, and that a guide can edit a users guest_trip details, etc'
         do_request
 
         expect(response).to be_successful
@@ -90,6 +92,7 @@ RSpec.describe 'GuestsController', type: :request do
 
     context 'valid and successful' do
       it 'should successfully render' do
+        pending 'see notes above'
         do_request
 
         expect(response).to be_successful
@@ -106,6 +109,7 @@ RSpec.describe 'GuestsController', type: :request do
     end
 
     it 'should successfully render' do
+      pending 'see notes above'
       do_request
 
       expect(response).to be_successful
@@ -124,6 +128,7 @@ RSpec.describe 'GuestsController', type: :request do
 
     context 'valid and successful' do
       it 'should successfully render' do
+        pending 'see notes above'
         do_request
 
         expect(response).to be_successful
@@ -155,6 +160,7 @@ RSpec.describe 'GuestsController', type: :request do
       }
 
       it 'should update the guest' do
+        pending 'See notes above'
         do_request(params: params)
 
         guest.reload

--- a/spec/requests/trips_controller_spec.rb
+++ b/spec/requests/trips_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'TripsController', type: :request do
       let(:trip) { Trip.last }
 
       it 'should create a new trip' do
+        pending 'only a signed in guide can create a trip'
         expect { do_request(params: params) }.to change { Trip.count }.by(1)
 
         expect(response.code).to eq '302'
@@ -67,6 +68,7 @@ RSpec.describe 'TripsController', type: :request do
 
     context 'valid and successful' do
       it 'should successfully render' do
+        pending 'see notes above'
         do_request
 
         expect(response).to be_successful
@@ -88,6 +90,7 @@ RSpec.describe 'TripsController', type: :request do
       let(:params) { { trip: { name: Faker::Name.name } } }
 
       it 'should update the trip name' do
+        pending 'see notes above'
         expect { do_request(params: params) }.to change { trip.reload.name }.to(params[:trip][:name])
       end
 


### PR DESCRIPTION
#### What's this PR do?
Add Devise to Users / Authenticate all routes

##### Background context
Part of the work to authenticate all sensitive actions across the app, this work adds Devise (authentication library added in previous work) to the User model.
Also, all actions are now authenticated.
We will choose, in subsequent work, which routes/ actions we will make public (ie: to allow a member of the public to join a trip, create a new guest, etc).
Adding this authentication breaks a number of specs. These have either been fixed in this work, or set to pending if more complicated, as they require more extensive follow up work. 

Ref: [Single Table Inheritance (STI) with Devise](https://vsmedia.co.uk/single-table-inheritance-sti-devise/) 

#### Where should the reviewer start?
db/schema.rb
 -> This is the easiest place to see what's changed with the user table/ model now. Encrypted password, etc now added.

#### How should this be manually tested?
Try and access any page, you will need to sign up. You've been authenticated.

#### Screenshots
Basic sign up page:
![image](https://user-images.githubusercontent.com/1453680/46306645-ba925880-c5ac-11e8-8c9c-15215d413155.png)

Basic sign in page:
![image](https://user-images.githubusercontent.com/1453680/46306610-a64e5b80-c5ac-11e8-9eaf-70b898cced49.png)


---

#### Migrations
Yes one, please run:

`rails db:migrate`

#### Additional deployment instructions
None.

#### Additional ENV Vars
None.
