### PR TITLE
Add Devise's log in and log out

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,12 +7,19 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
+// CSS
 import "../styles/application.scss";
+
+// JS
 import "bootstrap";
 import $ from "jquery";
+import Rails from "rails-ujs";
 import "popper.js";
-
-require.context("../images/", true, /\.(gif|jpe?g|png|svg)$/i);
 
 window.jQuery = $;
 window.$ = $;
+
+Rails.start();
+
+// Assets
+require.context("../images/", true, /\.(gif|jpe?g|png|svg)$/i);

--- a/app/views/layouts/_nav_bar.html.erb
+++ b/app/views/layouts/_nav_bar.html.erb
@@ -4,23 +4,34 @@
   <a class="navbar-brand" href="#">
     <img src="<%= asset_pack_path 'images/logo.svg' %>" />
   </a>
-  <ul class="navbar-nav ml-auto">
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <span class="ml-1 d-md-down-none">Mountain Trek Ltd.</span>
-        <img src="<%= asset_pack_path 'images/faces/face1.jpg' %>" class="avatar avatar-sm" alt="logo">
-      </a>
-      <div class="dropdown-menu dropdown-menu-right">
-        <a href="#" class="dropdown-item">
-          <i class="fa fa-user"></i> Manage Account
+  <% if guide_signed_in? %>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <% #TODO: replace with real data %>
+          <span class="ml-1 d-md-down-none">Mountain Trek Ltd.</span>
+          <img src="<%= asset_pack_path 'images/faces/face1.jpg' %>" class="avatar avatar-sm" alt="logo">
         </a>
-        <a href="#" class="dropdown-item">
-          <i class="fa fa-wrench"></i> Add Trip
-        </a>
-        <a href="#" class="dropdown-item">
-          <i class="fa fa-lock"></i> Sign Out
-        </a>
-      </div>
-    </li>
-  </ul>
+        <div class="dropdown-menu dropdown-menu-right">
+          <a href="#" class="dropdown-item">
+            <i class="fa fa-user"></i> Manage Account
+          </a>
+          <a href="#" class="dropdown-item">
+            <i class="fa fa-wrench"></i> Add Trip
+          </a>
+          <%= link_to(destroy_guide_session_path, method: :delete, class: "dropdown-item") do %>
+            <i class="fa fa-lock"></i> Sign Out
+          <% end %>
+        </div>
+      </li>
+    </ul>
+  <% else %>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item dropdown">
+        <%= link_to(new_guide_session_path) do %>
+          <i class="fa fa-lock"></i> Sign In
+        <% end %>
+      </li>
+    </ul>
+  <% end %>
 </nav>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "line-awesome": "^1.0.2",
     "material-icons": "^0.2.3",
     "node-sass": "^4.9.3",
-    "popper.js": "^1.14.4"
+    "popper.js": "^1.14.4",
+    "rails-ujs": "^5.2.1"
   },
   "devDependencies": {
     "webpack-dev-server": "2.11.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,6 +6149,10 @@ querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
 
+rails-ujs@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/rails-ujs/-/rails-ujs-5.2.1.tgz#2869c6d54fdfefac3aaa257f4efe211d8f5a7169"
+
 randomatic@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.0.tgz#36f2ca708e9e567f5ed2ec01949026d50aa10116"


### PR DESCRIPTION
#### What's this PR do?
Adds Devise's log in and log out

##### Background context
We want people to be able to log in and log out of the app.
Needed to install rails-ujs, yarn package, to make the sign out link send a DELETE request to Devise's SessionsController#destroy action.

#### Where should the reviewer start?
It's mostly in: app/views/layouts/_nav_bar.html.erb
Just followed Devise instructions - [How To: Add sign_in, sign_out, and sign_up links to your layout template ](https://github.com/plataformatec/devise/wiki/How-To:-Add-sign_in,-sign_out,-and-sign_up-links-to-your-layout-template )

#### How should this be manually tested?
Visit root. Sign up. You'll be logged in. 
Then hit the sign out link in the top right nav bar. You'll be signed out.
Make sure you can sign back in again.

#### Screenshots
Signed in...
![image](https://user-images.githubusercontent.com/1453680/46763428-b44d5c00-ccd1-11e8-870d-71e3f3f71280.png)

I go to sign out...
![image](https://user-images.githubusercontent.com/1453680/46763449-bf07f100-ccd1-11e8-97bf-5d896cf42201.png)

Hit sign out.. and... I'm signed out...
![image](https://user-images.githubusercontent.com/1453680/46763471-c929ef80-ccd1-11e8-84d9-2c3e5ea61728.png)


---

#### Migrations
None

#### Additional deployment instructions
Will need to run (to install rails-ujs):

`yarn`

#### Additional ENV Vars
None
