### PR TITLE
Add authorisation specs and remove guests#create

### DIFF
--- a/app/controllers/guests_controller.rb
+++ b/app/controllers/guests_controller.rb
@@ -21,15 +21,16 @@ class GuestsController < ApplicationController
   end
 
   # POST /guests
-  def create
-    @guest = Guest.new(guest_params)
+  # TODO: This is overridden by Devise::RegistrationsController#create
+  # def create
+  #   @guest = Guest.new(guest_params)
 
-    if @guest.save
-      redirect_to @guest, notice: 'Guest was successfully created.'
-    else
-      render :new
-    end
-  end
+  #   if @guest.save
+  #     redirect_to @guest, notice: 'Guest was successfully created.'
+  #   else
+  #     render :new
+  #   end
+  # end
 
   # PATCH/PUT /guests/1
   def update

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
   devise_for :guides
 
   resources :trips
-  resources :guests, only: %i(create edit index new show update)
+  resources :guests, only: %i(edit index new show update)
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,8 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/guests_controller_spec.rb
+++ b/spec/requests/guests_controller_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'GuestsController', type: :request do
-  # TODO: * need to test signed out users get redirected to sign in page
   # TODO: ** implement created_by and updated_by and test them here
 
   describe '#create POST /guests' do
+    include_examples 'authentication'
+
     # TODO: need to test the sign up path rather than directly creating a guest
     # Only guests can create themselves? By signing up?
-    # Revisit this when devise is installed
-    # TODO: * include_examples 'authentication' # signed out specs
+
     def do_request(url: "/guests", params: {})
       post url, params: params
     end
@@ -44,33 +44,21 @@ RSpec.describe 'GuestsController', type: :request do
     end
   end
 
-  describe '#destroy DELETE /guests/:id/' do
-    # TODO: DESTROY: who can do this?
-    # Soft delete?
-    # What do we really want to happen? - We prob only want to destroy the organisation_membership
-    # - by the owner of the organisation or the guest themselves.
-    # But allow a user to completely remove themselves and all their data from the system.
-    # let!(:guest) { create(:guest) }
-
-    # def do_request(url: "/guests/#{guest.id}", params: {})
-    #   delete url, params: params
-    # end
-  end
-
   describe '#edit GET /guests/:id/edit' do
+    include_examples 'authentication'
+
     # TODO: who can do this? A user can update their own details - need to scope this to current_user
     # A guide can edit a guests' organisation_membership but not the user details (email, etc).
     # Need to test that a guest / guide / public access - can not access this guest's edit page.
     # Need to scope so that only the current logged in user can update their own details.
     # Revisit when Devise is installed
-    # TODO: * include_examples 'authentication'
+
     let(:guest) { FactoryBot.create(:guest) }
 
     def do_request(url: "/guests/#{guest.id}/edit", params: {})
       get url, params: params
     end
 
-    
     context 'valid and successful' do
       it 'should successfully render' do
         pending 'Need to make sure that only a signed in user can edit their OWN details, and that a guide can edit a users guest_trip details, etc'
@@ -82,6 +70,8 @@ RSpec.describe 'GuestsController', type: :request do
   end
 
   describe '#index get /guests' do
+    include_examples 'authentication'
+
     # TODO: need to scope this to an organisation?
     # Test that current_user is organsation owner and they can only access their own organisation's users
     # All other cases, redirect to home page
@@ -101,6 +91,8 @@ RSpec.describe 'GuestsController', type: :request do
   end
 
   describe '#new get /guests/new' do
+    include_examples 'authentication'
+
     # TODO: This is the sign up page? Or is the creation of new guests done in the background
     # when a guest clicks on a guide's link to join a trip?
     # Revisit when Devise is installed
@@ -117,6 +109,8 @@ RSpec.describe 'GuestsController', type: :request do
   end
 
   describe '#show get /guests/:id' do
+    include_examples 'authentication'
+
     # TODO: Need to scope this to either a user, who can view ONLY their own details
     # OR: a guide who has a guest associated with their organisation
     # Revisit when Devise is installed
@@ -137,10 +131,11 @@ RSpec.describe 'GuestsController', type: :request do
   end
 
   describe '#update PATCH /guests/:id' do
+    include_examples 'authentication'
+
     # Need to scope so that only the current logged in user can update their own details.
     # An organisation owner, can update a user's other details, via their organisation_membership
     # Revist when Devise is installed
-    # TODO: * include_examples 'authentication'
     let!(:guest) { FactoryBot.create(:guest) }
 
     def do_request(url: "/guests/#{guest.id}", params: {})

--- a/spec/requests/guests_controller_spec.rb
+++ b/spec/requests/guests_controller_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe 'GuestsController', type: :request do
   # TODO: ** implement created_by and updated_by and test them here
 
   describe '#create POST /guests' do
-    include_examples 'authentication'
+    # TODO: this is overridden by Devise::RegistrationsController#create
+    # Need to make other route to allow a guide to add/ create a guest...
+    # include_examples 'authentication'
 
     # TODO: need to test the sign up path rather than directly creating a guest
     # Only guests can create themselves? By signing up?

--- a/spec/requests/trips_controller_spec.rb
+++ b/spec/requests/trips_controller_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 RSpec.describe 'TripsController', type: :request do
   # TODO: * need to test signed out users get redirected to sign in page/ public view of trip
+  # ... need to add a nested public scope to trips
   # TODO: ** implement created_by and updated_by and test them here
 
   describe '#create POST /trips' do
-    # TODO: revisit when devise is installed
-    # TODO: * include_examples 'authentication' # signed out specs
+    include_examples 'authentication'    
+
     def do_request(url: "/trips", params: {})
       post url, params: params
     end
@@ -17,6 +18,7 @@ RSpec.describe 'TripsController', type: :request do
 
       it 'should create a new trip' do
         pending 'only a signed in guide can create a trip'
+        # TODO: need to test that created trip is associated with current_guide
         expect { do_request(params: params) }.to change { Trip.count }.by(1)
 
         expect(response.code).to eq '302'
@@ -30,9 +32,8 @@ RSpec.describe 'TripsController', type: :request do
   end
 
   describe '#destroy DELETE /trips' do
-  # TODO: revisit when devise is installed
+  # include_examples 'authentication'
   # Soft delete?
-  # TODO: * include_examples 'authentication' # signed out specs
   # let!(:trip) { create(:trip) }
 
   # def do_request(url: "/trips/#{trip.id}", params: {})
@@ -57,8 +58,8 @@ RSpec.describe 'TripsController', type: :request do
   end
 
   describe '#edit GET /trips/:id/edit' do
-    # TODO: revisit when devise is installed
-    # TODO: * include_examples 'authentication'
+    include_examples 'authentication'
+
     # Only a trip owner / guide who belongs to this trip's org can edit a trip?
     let(:trip) { FactoryBot.create(:trip) }
 
@@ -77,8 +78,7 @@ RSpec.describe 'TripsController', type: :request do
   end
 
   describe '#update PATCH /trips/:id' do
-    # TODO: revisit when devise is installed
-    # TODO: * include_examples 'authentication'
+    include_examples 'authentication'
     # Only a trip owner / guide who belongs to this trip's org can edit a trip?
     let(:trip) { FactoryBot.create(:trip) }
 

--- a/spec/support/shared_examples/authentication.rb
+++ b/spec/support/shared_examples/authentication.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'authentication' do
+  context 'not signed in' do
+    it 'should redirect to the sign in page' do
+      do_request
+
+      expect(response).to redirect_to(new_guide_session_path)
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
Adds authorisation specs (checked non-logged in guides are redirected to new_session_path) 
And remove guests#create.

##### Background context
Now we have Devise in the app, we can add tests that the controllers require guides to be logged in to view all routes.

It was discovered by a failing test that the guests#create action is never used, as it is overridden by Devise::RegistrationsController#create

Further work will have a route that allows guides to create a guest and add them to a trip.

Further work will add a nested booking resource, which will have a public #new action, allowing Guide's to send out a trip/#{trip_id}/booking/new link to potential guests, to create a new booking.

#### Where should the reviewer start?
spec/support/shared_examples/authentication.rb - this explains what's being tested which is called in the test files via: 
include_examples 'authentication'

#### How should this be manually tested?
n/a

#### Screenshots
n/a

---

#### Migrations
none

#### Additional deployment instructions
none

#### Additional ENV Vars
none
