### PR TITLE
Remove Coveralls rake task.

### DIFF
--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,9 +1,0 @@
-unless Rails.env.production?
-  require 'rspec/core/rake_task'
-  require 'coveralls/rake/task'
-  Coveralls::RakeTask.new
-  namespace :ci do
-    desc 'Run all tests and generate a merged coverage report'
-    task tests: [:spec, 'coveralls:push']
-  end
-end


### PR DESCRIPTION
#### What's this PR do?
Remove Coveralls rake task.

##### Background context
This was added when Coveralls gem was added
...but was not removed when Coveralls was removed.

Unable to run rails db:migrate with this file present.

Added: https://github.com/Book-Your-Place/bookyourplace/pull/3/files
(Should of been) removed: https://github.com/Book-Your-Place/bookyourplace/pull/37

My mistake, sorry.