### PR TITLE
Add organisation model.

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,5 @@
+class Organisation < ApplicationRecord
+  validates :name, format: /\A[\sa-zA-Z0-9_.'\-]+\z/, allow_blank: false
+  validates :stripe_account_id, format: /\A[a-zA-Z0-9_\-]{5,50}\z/, allow_blank: true
+  validates :subdomain, format: /\A([a-zA-Z0-9][a-zA-Z0-9_\-]{3,30})\z/, allow_blank: true
+end

--- a/db/migrate/20181028115622_create_organisations.rb
+++ b/db/migrate/20181028115622_create_organisations.rb
@@ -1,0 +1,17 @@
+class CreateOrganisations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :organisations, id: :uuid do |t|
+      t.string :name
+      t.text :address
+      t.string :stripe_account_id
+      t.string :subdomain
+
+      t.uuid :created_by_id
+      t.uuid :updated_by_id
+
+      t.timestamps
+    end
+    add_foreign_key :organisations, :guides, column: :created_by_id, primary_key: :id
+    add_foreign_key :organisations, :guides, column: :updated_by_id, primary_key: :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_15_081332) do
+ActiveRecord::Schema.define(version: 2018_10_28_115622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -86,6 +86,17 @@ ActiveRecord::Schema.define(version: 2018_10_15_081332) do
     t.index ["trip_id", "guide_id"], name: "index_guides_trips_on_trip_id_and_guide_id"
   end
 
+  create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.text "address"
+    t.string "stripe_account_id"
+    t.string "subdomain"
+    t.uuid "created_by_id"
+    t.uuid "updated_by_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "trips", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.datetime "start_date"
@@ -100,4 +111,6 @@ ActiveRecord::Schema.define(version: 2018_10_15_081332) do
 
   add_foreign_key "bookings", "guests"
   add_foreign_key "bookings", "trips"
+  add_foreign_key "organisations", "guides", column: "created_by_id"
+  add_foreign_key "organisations", "guides", column: "updated_by_id"
 end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :organisation do
+    address { Faker::Address.full_address }
+    name { Faker::Name.name }
+    stripe_account_id { "acct_#{Faker::Bank.account_number(16)}" }
+    subdomain { Faker::Internet.domain_word }
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Organisation, type: :model do
+  describe 'associations' do
+    # TODO: 
+    # has_many: memberships: organisation_guide join table
+    # has_many: subscriptions (including one current_subscription)
+    # has_many: accomodation_providers
+  end
+
+  describe 'validations' do
+    context 'name' do
+      it { should allow_value(Faker::Lorem.word).for(:name) }
+      it { should_not allow_value('<SQL INJECTION>').for(:name) }
+    end
+    context 'stripe_account_id' do
+      it { should allow_value("acct_#{Faker::Number.number(15)}").for(:stripe_account_id) }
+      it { should_not allow_value("!<>*&^%").for(:stripe_account_id) }
+    end
+    context 'subdomain' do
+      it { should allow_value(Faker::Internet.domain_word).for(:subdomain) }
+      it { should_not allow_value("-#{Faker::Internet.domain_word}").for(:subdomain) } # beginning with '-'
+      it { should_not allow_value("!<>*&^%").for(:subdomain) }
+      it { should_not allow_value("12").for(:subdomain) } # < 3 digits
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
Add organisation model.

##### Background context
Part of the work to incorporate Stripe API.

We are only building out the specific models from the [entity relationship diagram](https://docs.google.com/presentation/d/1Xilql2vzIe8jNsuiGR6r1aN5_45nUQpMgRAUIAXAMqU/edit?usp=sharing) as and when required in the app layer.

When a booking is created, we need to know which connected account to pay the charge into.
An organisation has a stripe_account_id which we will use to make this payment.

Subsequent work will add the models and their associations with this organisation model.

#### Where should the reviewer start?
db/*  - explains in SQL this new model
app/models/organisation.rb - in the app layer and...
spec/models/organisation_spec.rb - explains more in the testing...

#### How should this be manually tested?
Not plumbed in yet.

#### Screenshots
n/a

---

#### Migrations
Yes one.

Need to run: `rails db:migrate`

#### Additional deployment instructions
None

#### Additional ENV Vars
None
