### PR TITLE
Use bookings as join table between guests and trips.

### DIFF
--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -4,7 +4,8 @@ class Guest < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_and_belongs_to_many :trips
+  has_many :bookings
+  has_many :trips, through: :bookings
 
   validates :email, format: /\A\w+@\w+\.{1}[a-zA-Z]{2,}\z/, presence: true, uniqueness: true
   validates :name, format: /\A[\sa-zA-Z0-9_.'\-]+\z/, allow_blank: true

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -4,10 +4,9 @@ class Trip < ApplicationRecord
   validates :minimum_number_of_guests, numericality: { only_integer: true }, allow_nil: true
   validates :maximum_number_of_guests, numericality: { only_integer: true }, allow_nil: true
 
-  has_and_belongs_to_many :guests
-  has_and_belongs_to_many :guides
-
   has_many :bookings
+  has_many :guests, through: :bookings
+  has_and_belongs_to_many :guides
  
   def valid_date_format
     # TODO: implement when we know the format of the date string we are receiving

--- a/db/migrate/20181029143353_drop_guests_trips_join_table.rb
+++ b/db/migrate/20181029143353_drop_guests_trips_join_table.rb
@@ -1,0 +1,5 @@
+class DropGuestsTripsJoinTable < ActiveRecord::Migration[5.2]
+  def change
+    drop_join_table :guests, :trips
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_28_115622) do
+ActiveRecord::Schema.define(version: 2018_10_29_143353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -45,17 +45,6 @@ ActiveRecord::Schema.define(version: 2018_10_28_115622) do
     t.uuid "updated_by_id"
     t.index ["email"], name: "index_guests_on_email", unique: true
     t.index ["reset_password_token"], name: "index_guests_on_reset_password_token", unique: true
-  end
-
-  create_table "guests_trips", id: false, force: :cascade do |t|
-    t.uuid "guest_id", null: false
-    t.uuid "trip_id", null: false
-    t.uuid "created_by_id"
-    t.uuid "updated_by_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["guest_id", "trip_id"], name: "index_guests_trips_on_guest_id_and_trip_id"
-    t.index ["trip_id", "guest_id"], name: "index_guests_trips_on_trip_id_and_guest_id"
   end
 
   create_table "guides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/guest_spec.rb
+++ b/spec/models/guest_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Guest, type: :model do
   describe 'associations' do
-    it { is_expected.to have_and_belong_to_many(:trips) }
+    it { should have_many(:bookings) }
+    it { should have_many(:trips).through(:bookings) }
   end
 
   describe 'validations' do

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Trip, type: :model do
   describe 'associations' do
-    it { is_expected.to have_and_belong_to_many(:guests) }
-    it { is_expected.to have_and_belong_to_many(:guides) }
-    it { is_expected.to have_many(:bookings) }
+    it { should have_many(:bookings) }
+    it { should have_many(:guests).through(:bookings) }
+    it { should have_and_belong_to_many(:guides) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
#### What's this PR do?
Uses bookings as join table between guests and trips, rather than guest_trips.

##### Background context
Part of the work to allow a booking to create a guest and associate that guest with a trip.

It became clear that the join_table 'guests_trips' was a duplication
of the 'booking' table model. The booking table will have / has more
required functionality than a simple join table, so makes sense to
delete the guest_trips table and fix up all macros and specs to reflect
this.

The join table guides_trips is left intact.

#### Where should the reviewer start?
db/* - this has the simple migration dropping the table and indexes AND the resultant change in the db/schema.rb
The rest of the changes are tweaks in the macros' in the app layer, and changes to reflect the db and app layer changes in the test files.

#### How should this be manually tested?
n/a - not really plumbed in yet...

#### Screenshots
n/a

---

#### Migrations
Yes, one. Please run: `rails db:migrate`

#### Additional deployment instructions
none

#### Additional ENV Vars
none
