### PR TITLE
Allow guests to be created without password

### DIFF
--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -10,4 +10,8 @@ class Guest < ApplicationRecord
   validates :email, format: /\A\w+@\w+\.{1}[a-zA-Z]{2,}\z/, presence: true, uniqueness: true
   validates :name, format: /\A[\sa-zA-Z0-9_.'\-]+\z/, allow_blank: true
   validates :phone_number, format: /\A[0-9+.x()\-\s]{7,}\z/, allow_blank: true
+
+  def password_required?
+    false
+  end
 end


### PR DESCRIPTION
#### What's this PR do?
Allows guests to be created without password

##### Background context
Part of the work to allow a booking to create a guest and associate that guest with a trip.

Devise, by default, forces all its models to have their password field set.
This doesn't make sense in this case, when a guest is automatically created by the scenes, when a booking is created.

Subsequent work will send an email out to a guest, to make sure they have confirmed their email and set a password, before they can perform any more actions, such as book another trip, any kind of payment, edit guest, etc.

#### Where should the reviewer start?
app/models/guest.rb - that is all...
Subsequent work/ PR will see this in action and covered by request specs.

#### How should this be manually tested?
n/a - not plumbed in yet.

#### Screenshots
n/a

---

#### Migrations
none

#### Additional deployment instructions
none

#### Additional ENV Vars
none
