### PR TITLE
Find or create guest when creating a new booking.

### DIFF
--- a/app/controllers/public/trips/bookings_controller.rb
+++ b/app/controllers/public/trips/bookings_controller.rb
@@ -4,6 +4,7 @@ module Public
       skip_before_action :authenticate_guide!
       before_action :set_booking, only: [:show, :edit, :update]
       before_action :set_trip, only: [:create, :new]
+      before_action :set_guest, only: [:create]
 
       # GET /bookings/1
       def show
@@ -20,7 +21,7 @@ module Public
 
       # POST /bookings
       def create
-        @booking = @trip.bookings.new(booking_params)
+        @booking = @trip.bookings.new(booking_params.merge(guest: @guest))
 
         if @booking.save
           redirect_to public_booking_path(@booking), notice: 'Booking was successfully created.'
@@ -44,6 +45,10 @@ module Public
         @booking = Booking.find(params[:id])
       end
 
+      def set_guest
+        @guest = Guest.find_or_create_by!(email: guest_params[:email])
+      end
+
       def set_trip
         @trip = Trip.find(params[:trip_id])
       end
@@ -51,6 +56,10 @@ module Public
       # Only allow a trusted parameter "white list" through.
       def booking_params
         params.require(:booking).permit()
+      end
+
+      def guest_params
+        params.require(:booking).permit(:email)
       end
     end
   end

--- a/app/views/public/trips/bookings/_form.html.erb
+++ b/app/views/public/trips/bookings/_form.html.erb
@@ -11,8 +11,10 @@
     </div>
   <% end %>
 
-  <%= form.hidden_field(:status, value: :complete) %>
+  <%= form.label(:email) %>
+  <%= form.text_field(:email) %>
 
+  <%= form.hidden_field(:status, value: :complete) %>
   <div class="actions">
     <%= form.submit %>
   </div>


### PR DESCRIPTION
#### What's this PR do?
Finds or creates guest when creating a new booking.

##### Background context
Part of the work to allow a booking to create a guest and associate that guest with a trip.

Once a user has used the public booking page to make a payment, we get the stripe token from Stripe and post to bookings#create.
This then uses the email in the bookings#new form to find or create a user and associate them with the booking and thus the trip.

Subsequent work will use the stripe token to actually make the charge on the guest's card and funnel that over to the trip owner's organisation connected/destination account. And redirect to public/guest/:guest_id/edit

#### Where should the reviewer start?
app/controllers/public/trips/bookings_controller.rb
 - this is where the new functionality is all happening, then covered in associated request spec.

#### How should this be manually tested?
Go to public/trip/:trip_id/bookings/new, add an email address, hit submit button and you should be able to create a new booking (and behind the scenes a guest).

#### Screenshots
![image](https://user-images.githubusercontent.com/1453680/47661123-4f7a7880-db90-11e8-8b86-1056a3bc9b88.png)


![image](https://user-images.githubusercontent.com/1453680/47661061-383b8b00-db90-11e8-9cba-bb78a5b683e1.png)

---

#### Migrations
none

#### Additional deployment instructions
none

#### Additional ENV Vars
none
