### PR TITLE
Redirect to public guest edit view

### DIFF
--- a/app/controllers/public/guests_controller.rb
+++ b/app/controllers/public/guests_controller.rb
@@ -1,0 +1,56 @@
+module Public
+  class GuestsController < ApplicationController
+    TIMEOUT_WINDOW_MINUTES = 30
+    skip_before_action :authenticate_guide! # / :authenticate_guest! ?
+    before_action :set_guest_and_check_timeout, only: %i[edit update show]
+
+    # GET /public/guests/:guest_id/edit
+    def edit
+    end
+
+    # PATCH/PUT /public/guests/:guest_id
+    def update
+      if @guest.update(guest_params)
+        redirect_to public_guest_path(@guest), notice: 'Guest was successfully updated.'
+      else
+        render :edit
+      end
+    end
+
+    # GET /public/guests/:guest_id
+    def show
+    end
+
+    private
+
+    def set_guest_and_check_timeout
+      set_guest
+      check_timeout
+    end
+
+    def check_timeout
+      return if newly_created?
+      @guest.errors.add(:base, :timeout, message: 'timed out please contact support')
+      # TODO: make fallback_location to the public/trip#show path when built in. Need to pass in trip id in hidden field
+      redirect_back(fallback_location: root_path)
+    end
+
+    def newly_created?
+      @guest.created_at > TIMEOUT_WINDOW_MINUTES.minutes.ago
+    end
+
+    # Use callbacks to share common setup or constraints between actions.
+    def set_guest
+      # TODO: scope this to an organisation
+      @guest = Guest.find(params[:id])
+    end
+
+    # Only allow a trusted parameter "white list" through.
+    def guest_params
+      params.require(:guest).permit(:address,
+                                    :email, # TODO: Do we want to allow guests to change their email via the public page
+                                    :name,
+                                    :phone_number)
+    end
+  end
+end

--- a/app/controllers/public/trips/bookings_controller.rb
+++ b/app/controllers/public/trips/bookings_controller.rb
@@ -24,7 +24,7 @@ module Public
         @booking = @trip.bookings.new(booking_params.merge(guest: @guest))
 
         if @booking.save
-          redirect_to public_booking_path(@booking), notice: 'Booking was successfully created.'
+          redirect_to edit_public_guest_path(@guest), notice: 'Booking was successfully created.'
         else
           render :new
         end

--- a/app/views/public/guests/_form.html.erb
+++ b/app/views/public/guests/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_with(model: guest, local: true) do |form| %>
+  <% if guest.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(guest.errors.count, "error") %> prohibited this guest from being saved:</h2>
+
+      <ul>
+      <% guest.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= form.label :address %>
+  <%= form.text_field :address %>
+  <%= form.label :email %>
+  <%= form.text_field :email %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/public/guests/edit.html.erb
+++ b/app/views/public/guests/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Guest</h1>
+
+<%= render 'form', guest: @guest %>
+
+<%= link_to 'Show', @guest %> |
+<%= link_to 'Back', guests_path %>

--- a/app/views/public/guests/new.html.erb
+++ b/app/views/public/guests/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Guest</h1>
+
+<%= render 'form', guest: @guest %>
+
+<%= link_to 'Back', guests_path %>

--- a/app/views/public/guests/show.html.erb
+++ b/app/views/public/guests/show.html.erb
@@ -1,0 +1,4 @@
+<p id="notice"><%= notice %></p>
+
+<%= link_to 'Edit', edit_guest_path(@guest) %> |
+<%= link_to 'Back', guests_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   resources :guests, only: %i(edit index new show update)
 
   namespace :public do
+    resources :guests, only: %i(edit update show)
     resources :trips, only: %i() do
       resources :bookings, only: %i(create edit new show update),
                            shallow: true, controller: '/public/trips/bookings'

--- a/spec/requests/public/guests_controller_spec.rb
+++ b/spec/requests/public/guests_controller_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe 'Public::GuestsController', type: :request do
+  context 'within timeout window of guest being created' do
+    let(:guest) { FactoryBot.create(:guest, created_at: 10.minutes.ago)}
+
+    describe '#show GET /public/guests/:id' do
+      def do_request(url: "/public/guests/#{guest.id}", params: {})
+        get url, params: params
+      end
+
+      it 'should successfully render' do
+        do_request
+
+        expect(response).to be_successful
+      end
+    end
+
+    describe '#edit GET /public/guests/:id/edit' do
+      def do_request(url: "/public/guests/#{guest.id}/edit", params: {})
+        get url, params: params
+      end
+
+      it 'should successfully render' do
+        do_request
+
+        expect(response).to be_successful
+      end
+    end
+
+    describe '#update PATCH /public/guests/:id' do
+      let!(:email) { Faker::Internet.email }
+      let!(:guest) { FactoryBot.create(:guest) }
+      # TODO: Do we want to allow public editing of guests' email?
+      let(:params) { { guest: { email: email } } }
+
+      def do_request(url: "/public/guests/#{guest.id}", params: {})
+        patch url, params: params
+      end
+
+      it 'should update the guest' do
+        do_request(params: params)
+
+        expect(response.code).to eq '302'
+        expect(response).to redirect_to(public_guest_path(guest))
+
+        expect(guest.reload.email).to eq email
+      end
+    end
+  end
+
+  context 'timeout window of guest creation has expired' do
+    let(:guest) { FactoryBot.create(:guest, created_at: 40.minutes.ago)}
+
+    describe '#show GET /public/guests/:id' do
+      def do_request(url: "/public/guests/#{guest.id}", params: {})
+        get url, params: params
+      end
+
+      it 'should redirect to root path' do # TODO: redirect to public/trip#show path when built in.
+        do_request
+
+        expect(response.code).to eq '302'
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe '#edit GET /public/guests/:id/edit' do
+      def do_request(url: "/public/guests/#{guest.id}/edit", params: {})
+        get url, params: params
+      end
+
+      it 'should redirect to root path' do # TODO: redirect to public/trip#show path when built in.
+        do_request
+
+        expect(response.code).to eq '302'
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe '#update PATCH /public/guests/:id' do # TODO: redirect to public/trip#show path when built in.
+      def do_request(url: "/public/guests/#{guest.id}", params: {})
+        patch url, params: params
+      end
+
+      it 'should redirect to root path' do
+        do_request
+
+        expect(response.code).to eq '302'
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/public/trips/bookings_controller_spec.rb
+++ b/spec/requests/public/trips/bookings_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Public::Trips::BookingsController', type: :request do
         expect(trip.guests).to include guest
 
         expect(response.code).to eq '302'
-        expect(response).to redirect_to(public_booking_path(booking))
+        expect(response).to redirect_to(edit_public_guest_path(guest))
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe 'Public::Trips::BookingsController', type: :request do
         expect(trip.guests).to include guest
 
         expect(response.code).to eq '302'
-        expect(response).to redirect_to(public_booking_path(booking))
+        expect(response).to redirect_to(edit_public_guest_path(guest))
       end
     end
   end


### PR DESCRIPTION
#### What's this PR do?
Redirect to public guest edit view once a new booking has been created.

##### Background context
Part of the work to allow a booking to create a guest and associate that guest with a trip.

Once a booking has been made, we want to get the new guest to add their extra details (address, phone number, etc) to their guest record so the guide can access this later.

For security reasons, the new guest can only access this public guest/edit view for the first 30 minutes after the guest is created.

Subsequent work will add a public/trips/:trip_id page so that, if the trip_id is present in the params, we can redirect the guest back to that page, or perhaps the guest log in page. Still to be decided...

There needs to be a lot of work on separating the controllers that require authenticate_guide! vs authenticate_guest! and having a tidy up of all controllers, models, their associations and scopes and associated test coverage to make sure every controller is secure or public when we want to it be.

#### Where should the reviewer start?
app/controllers/public/guests_controller.rb
the associated views (app/views/public/guest/*) have literally been copied from app/views/guest/*.
Leaving all views as completely un-styled so that's clear what has been gone through the design process and what hasn't.

#### How should this be manually tested?
Go to make a new booking for a trip (eg: http://localhost:3000/public/trips/:trip_id/bookings/new)
Enter email address and hit "create booking"
You will see the guest edit page.

Leave it > 30 mins... and refresh the page, you will not be able to access it.


#### Screenshots
new booking page (as it was previously):
![image](https://user-images.githubusercontent.com/1453680/47703967-e4758400-dc19-11e8-830d-6db4acd1cc6a.png)


public guest edit page:
![image](https://user-images.githubusercontent.com/1453680/47703945-ce67c380-dc19-11e8-993e-f34c236132fd.png)

Trying to access the public guest edit page (after 30 mins):
![image](https://user-images.githubusercontent.com/1453680/47704029-24d50200-dc1a-11e8-81a5-b5dd971bbc9d.png)


---

#### Migrations
none

#### Additional deployment instructions
none

#### Additional ENV Vars
none
