### PR TITLE
Create organisation membership join table

### DIFF
--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -4,6 +4,8 @@ class Guide < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :organisation_memberships
+  has_many :organisations, through: :organisation_memberships
   has_and_belongs_to_many :trips
 
   validates :email, format: /\A\w+@\w+\.{1}[a-zA-Z]{2,}\z/, presence: true, uniqueness: true

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,4 +2,7 @@ class Organisation < ApplicationRecord
   validates :name, format: /\A[\sa-zA-Z0-9_.'\-]+\z/, allow_blank: false
   validates :stripe_account_id, format: /\A[a-zA-Z0-9_\-]{5,50}\z/, allow_blank: true
   validates :subdomain, format: /\A([a-zA-Z0-9][a-zA-Z0-9_\-]{3,30})\z/, allow_blank: true
+
+  has_many :organisation_memberships
+  has_many :guides, through: :organisation_memberships
 end

--- a/app/models/organisation_membership.rb
+++ b/app/models/organisation_membership.rb
@@ -1,0 +1,6 @@
+class OrganisationMembership < ApplicationRecord
+  belongs_to :organisation
+  belongs_to :guide
+
+  validates_uniqueness_of :guide, scope: :organisation
+end

--- a/db/migrate/20181030201440_create_organisation_memberships.rb
+++ b/db/migrate/20181030201440_create_organisation_memberships.rb
@@ -1,0 +1,11 @@
+class CreateOrganisationMemberships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :organisation_memberships, id: :uuid do |t|
+      t.boolean :owner, default: false
+      t.references :organisation, foreign_key: true, index: true, type: :uuid
+      t.references :guide, foreign_key: true, index: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_29_143353) do
+ActiveRecord::Schema.define(version: 2018_10_30_201440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -75,6 +75,16 @@ ActiveRecord::Schema.define(version: 2018_10_29_143353) do
     t.index ["trip_id", "guide_id"], name: "index_guides_trips_on_trip_id_and_guide_id"
   end
 
+  create_table "organisation_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "owner", default: false
+    t.uuid "organisation_id"
+    t.uuid "guide_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["guide_id"], name: "index_organisation_memberships_on_guide_id"
+    t.index ["organisation_id"], name: "index_organisation_memberships_on_organisation_id"
+  end
+
   create_table "organisations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.text "address"
@@ -100,6 +110,8 @@ ActiveRecord::Schema.define(version: 2018_10_29_143353) do
 
   add_foreign_key "bookings", "guests"
   add_foreign_key "bookings", "trips"
+  add_foreign_key "organisation_memberships", "guides"
+  add_foreign_key "organisation_memberships", "organisations"
   add_foreign_key "organisations", "guides", column: "created_by_id"
   add_foreign_key "organisations", "guides", column: "updated_by_id"
 end

--- a/spec/factories/organisation_membership.rb
+++ b/spec/factories/organisation_membership.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :organisation_membership do
+    guide
+    organisation
+  end
+end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Guide, type: :model do
   describe 'associations' do
     it { is_expected.to have_and_belong_to_many(:trips) }
+    it { should have_many(:organisations).through(:organisation_memberships) }
   end
 
   describe 'validations' do

--- a/spec/models/organisation_membership_spec.rb
+++ b/spec/models/organisation_membership_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe OrganisationMembership, type: :model do
+  describe 'associations' do
+    it { should belong_to(:guide) }
+    it { should belong_to(:organisation) }
+  end
+
+  describe 'validations' do
+    context 'uniqueness' do
+      context 'a guide is a member of an organisation once' do
+        let!(:organisation) { FactoryBot.create(:organisation) }
+        let!(:guide) { FactoryBot.create(:guide) }
+        let!(:organisation_membership) do
+          FactoryBot.build(:organisation_membership, guide: guide, organisation: organisation)
+        end
+
+        it { expect(organisation_membership).to be_valid }
+      end
+
+      context 'a guide is a member of the same organisation twice' do
+        let!(:organisation) { FactoryBot.create(:organisation) }
+        let!(:guide) { FactoryBot.create(:guide) }
+        let!(:organisation_membership) do 
+          FactoryBot.create(:organisation_membership, guide: guide, organisation: organisation)
+        end
+        let!(:duplicate_organisation_membership) do 
+          FactoryBot.build(:organisation_membership, guide: guide, organisation: organisation)
+        end
+
+        it { expect(duplicate_organisation_membership).to_not be_valid }
+      end
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Organisation, type: :model do
   describe 'associations' do
+    it { should have_many(:guides).through(:organisation_memberships) }
     # TODO: 
-    # has_many: memberships: organisation_guide join table
     # has_many: subscriptions (including one current_subscription)
     # has_many: accomodation_providers
   end


### PR DESCRIPTION
#### What's this PR do?
Creates the organisation_membership (between an organisation and guide) join table.

##### Background context
Part of the work to allow guides to share a public link to make a new booking with a member of public.

We need to associate organisations with guides so that we can use the stripe_account_id associated with an organisation to make a charge to that organisation's stripe destination account.

Subsequent work will associate the trip -> owner (guide) -> organisation, so we can access the relevant organisation associated with the trip's new booking, when the booking is created.

Also, will implement the "owner" functionality. An organisation can have an owner guide, which is determined on this join model. 

#### Where should the reviewer start?
db/* shows the most basic changes,
everything else in app layer, is just adding macros so the models can reference each other.

#### How should this be manually tested?
Not plumbed in yet.

#### Screenshots
n/a

---

#### Migrations
Yes  - one, Pleas run: `rails db:migrate`

#### Additional deployment instructions
none

#### Additional ENV Vars
none
