### PR TITLE
Add organisation to trips

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,4 +5,5 @@ class Organisation < ApplicationRecord
 
   has_many :organisation_memberships
   has_many :guides, through: :organisation_memberships
+  has_many :trips
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -4,6 +4,7 @@ class Trip < ApplicationRecord
   validates :minimum_number_of_guests, numericality: { only_integer: true }, allow_nil: true
   validates :maximum_number_of_guests, numericality: { only_integer: true }, allow_nil: true
 
+  belongs_to :organisation
   has_many :bookings
   has_many :guests, through: :bookings
   has_and_belongs_to_many :guides

--- a/db/migrate/20181031193044_add_organisation_to_trips.rb
+++ b/db/migrate/20181031193044_add_organisation_to_trips.rb
@@ -1,0 +1,5 @@
+class AddOrganisationToTrips < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :trips, :organisation, foreign_key: true, index: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_30_201440) do
+ActiveRecord::Schema.define(version: 2018_10_31_193044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -106,6 +106,8 @@ ActiveRecord::Schema.define(version: 2018_10_30_201440) do
     t.uuid "updated_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "organisation_id"
+    t.index ["organisation_id"], name: "index_trips_on_organisation_id"
   end
 
   add_foreign_key "bookings", "guests"
@@ -114,4 +116,5 @@ ActiveRecord::Schema.define(version: 2018_10_30_201440) do
   add_foreign_key "organisation_memberships", "organisations"
   add_foreign_key "organisations", "guides", column: "created_by_id"
   add_foreign_key "organisations", "guides", column: "updated_by_id"
+  add_foreign_key "trips", "organisations"
 end

--- a/spec/factories/trip.rb
+++ b/spec/factories/trip.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :trip do
     name { Faker::Name.name }
+    organisation
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Organisation, type: :model do
   describe 'associations' do
     it { should have_many(:guides).through(:organisation_memberships) }
+    it { should have_many(:trips) }
     # TODO: 
     # has_many: subscriptions (including one current_subscription)
     # has_many: accomodation_providers

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Trip, type: :model do
   describe 'associations' do
+    it { should belong_to(:organisation) }
     it { should have_many(:bookings) }
     it { should have_many(:guests).through(:bookings) }
     it { should have_and_belong_to_many(:guides) }


### PR DESCRIPTION
#### What's this PR do?
Add organisation reference to trips.

##### Background context
Continue the work of building out this [entity relationship diagram](https://docs.google.com/presentation/d/1Xilql2vzIe8jNsuiGR6r1aN5_45nUQpMgRAUIAXAMqU/edit?usp=sharing).

Previous work created the OrganisationMemberships join table between organisations and guides, which had a boolean owner field to indicate if that guide was the owner of that organisation.

But when creating a new booking, where we only have the reference to the trip, there is no way to find out which guide (associated with the trip) was the owner of the correct organisation (the organisation that owned this trip.)

This work fixes that by adding a simple organisation reference to the trip model.
Subsequent work, may remove the owner field from the OrganisationMembership model and just add a simpler owner/ guide reference directly on the organisation model. Although, this may prevent an organisation being owned by multiple guides (ie: a couple), and goes against the organisation has_many guides pattern we definitely need.

#### Where should the reviewer start?
db/* - this has the simple changes and explains the change.
app/models/* - just updates to the (has_many, belongs_to) macros
and specs/ to cover the new expected relationship.


#### How should this be manually tested?
n/a - Not plumbed in yet.

#### Screenshots
n/a

---

#### Migrations
yes  - one.
`rails db:migrate`

#### Additional deployment instructions
none

#### Additional ENV Vars
none
