### PR TITLE
Add SideKiq gem for background job processing.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'devise'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
+gem 'sidekiq'
 gem 'stripe'
 gem 'webpacker'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     byebug (10.0.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.2)
     crass (1.0.4)
     devise (4.5.0)
       bcrypt (~> 3.0)
@@ -60,8 +61,6 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.1)
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
@@ -113,6 +112,8 @@ GEM
       pry (~> 0.10)
     puma (3.12.0)
     rack (2.0.5)
+    rack-protection (2.0.4)
+      rack
     rack-proxy (0.6.4)
       rack
     rack-test (1.1.0)
@@ -145,6 +146,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redis (4.0.3)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -168,6 +170,10 @@ GEM
     ruby_dep (1.5.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
+    sidekiq (5.2.2)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -187,8 +193,6 @@ GEM
       sprockets (>= 3.0.0)
     stripe (3.28.0)
       faraday (~> 0.10)
-    term-ansicolor (1.6.0)
-      tins (~> 1.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -225,6 +229,7 @@ DEPENDENCIES
   rails (~> 5.2.1)
   rspec-rails
   shoulda-matchers
+  sidekiq
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
@@ -236,4 +241,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+worker: bundle exec sidekiq -q default -q mailers

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,7 @@ module Bookyourplace
     end
 
     config.autoload_paths += %W(#{config.root}/app/models/users)
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end


### PR DESCRIPTION
#### What's this PR do?
Add SideKiq gem for background job processing.

##### Background context
Part of the work to charge guests and make payments to guides.

We want to remove all calls to external services (ie: Stripe) out of the web request cycle and into background jobs... I think... Once we start working with Stripe API properly, we will learn the appropriate UX - either requesting charges in a (user facing) web request cycle, or in a background job. Either way, we will need a way to process long running background jobs: sending email, etc.

Subsequent work will include creating a ActiveJob for make requests to Stripe and UX regarding letting the guest know if the charge has been successful or not.

#### Where should the reviewer start?
It's pretty much all config changes simply by following instructions from here:
https://github.com/mperham/sidekiq/wiki/Active-Job
https://azukiweb.com/blog/2015/activejob-on-heroku-rails-4/

#### How should this be manually tested?
n/a - not plumbed in yet

#### Screenshots
If you're really interested...
1) Running an example job in the background (in the console):
![image](https://user-images.githubusercontent.com/1453680/47929586-5e7b6680-dec1-11e8-8a98-bd1541133346.png)


2)
Picked up by SideKiq (via the sever logs):
![image](https://user-images.githubusercontent.com/1453680/47929633-85399d00-dec1-11e8-80cd-fc6dbcc89c30.png)


---

#### Migrations
None.

#### Additional deployment instructions

Locally:
Follow these instructions: https://azukiweb.com/blog/2015/activejob-on-heroku-rails-4/
brew install redis // install redis:
brew services start redis // run redis
heroku local // run heroku locally, which will create processes (including the web and background process) based off the Procfile

On Heroku:
Will need to set up on Heroku:
1) Add the Redis element/plug in
2) Add a background dyno to handle background jobs (costs $, so will do when we really need to).

#### Additional ENV Vars
none - but RAILS_MAX_THREADS_SIDEKIQ may come later...
