### PR TITLE
Create subscription model

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,6 @@
+class Subscription < ApplicationRecord
+  belongs_to :organisation
+  belongs_to :plan
+
+  scope :created_at_desc, -> { order(created_at: :desc) }
+end

--- a/db/migrate/20181103154415_create_subscriptions.rb
+++ b/db/migrate/20181103154415_create_subscriptions.rb
@@ -1,0 +1,15 @@
+class CreateSubscriptions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :subscriptions, id: :uuid do |t|
+      t.column :created_by_id, :uuid
+      t.column :updated_by_id, :uuid
+
+      t.references :organisation, type: :uuid, foreign_key: true, index: true
+      t.references :plan, type: :uuid, foreign_key: true, index: true
+
+      t.timestamps
+    end
+    add_index :subscriptions, :created_by_id
+    add_index :subscriptions, :updated_by_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_03_141301) do
+ActiveRecord::Schema.define(version: 2018_11_03_154415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -105,6 +105,19 @@ ActiveRecord::Schema.define(version: 2018_11_03_141301) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "created_by_id"
+    t.uuid "updated_by_id"
+    t.uuid "organisation_id"
+    t.uuid "plan_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_by_id"], name: "index_subscriptions_on_created_by_id"
+    t.index ["organisation_id"], name: "index_subscriptions_on_organisation_id"
+    t.index ["plan_id"], name: "index_subscriptions_on_plan_id"
+    t.index ["updated_by_id"], name: "index_subscriptions_on_updated_by_id"
+  end
+
   create_table "trips", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.datetime "start_date"
@@ -125,5 +138,7 @@ ActiveRecord::Schema.define(version: 2018_11_03_141301) do
   add_foreign_key "organisation_memberships", "organisations"
   add_foreign_key "organisations", "guides", column: "created_by_id"
   add_foreign_key "organisations", "guides", column: "updated_by_id"
+  add_foreign_key "subscriptions", "organisations"
+  add_foreign_key "subscriptions", "plans"
   add_foreign_key "trips", "organisations"
 end

--- a/spec/factories/subscription.rb
+++ b/spec/factories/subscription.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :subscription do
+    organisation
+    plan
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Subscription, type: :model do
+  describe 'associations' do
+    it { should belong_to(:organisation) }
+    it { should belong_to(:plan) }
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
Creates the subscription model

##### Background context
Part of the work to allow guests to make a payment to a guide.
A guide's organisation will have a subscription to a plan. We will then use the details of the plan (flat fee amount, etc) to make an application/ plaftorm charge to our account when a guest pays for a full booking.

It may be useful to keep track of all the subscriptions/ plans a guide has had, so we will allow multiple subscriptions to exist as a record of plan changes, but there will only ever be one current_subscription / plan for an organisation, which we will use as the basis of the platform charge.

Subsequent work will expose the subscription / current_subscription and plan in the organisation model.

#### Where should the reviewer start?
All pretty standard / expected stuff now when a new model is added, ie:
db/* - migration and schema change
app/models/* - new model itself and any association macros in the app layer
spec/* - model spec and factory creation files.

#### How should this be manually tested?
n/a - not plumbed in yet.

#### Screenshots
n/a

---

#### Migrations
Yes one. Please run:

`rails db:migrate`


#### Additional deployment instructions
none

#### Additional ENV Vars
none
