### PR TITLE
Add subscription to organisation and plan models

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,5 +5,16 @@ class Organisation < ApplicationRecord
 
   has_many :organisation_memberships
   has_many :guides, through: :organisation_memberships
+  has_many :subscriptions
   has_many :trips
+
+  def plan
+    current_subscription&.plan
+  end
+
+  private
+
+  def current_subscription
+    subscriptions.created_at_desc&.first
+  end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,6 +1,8 @@
 class Plan < ApplicationRecord
   enum charge_type: [ :flat_fee, :percentage ]
 
+  has_many :subscriptions
+
   validates :name, presence: true
   validate :charge_amount_present
 

--- a/spec/factories/plan.rb
+++ b/spec/factories/plan.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :plan do
     name { Faker::Name.name }
-    charge_type { :flat_fee } 
+    charge_type { :flat_fee }
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Organisation, type: :model do
   describe 'associations' do
     it { should have_many(:guides).through(:organisation_memberships) }
+    it { should have_many(:subscriptions) }
     it { should have_many(:trips) }
     # TODO: 
-    # has_many: subscriptions (including one current_subscription)
     # has_many: accomodation_providers
   end
 
@@ -23,6 +23,19 @@ RSpec.describe Organisation, type: :model do
       it { should_not allow_value("-#{Faker::Internet.domain_word}").for(:subdomain) } # beginning with '-'
       it { should_not allow_value("!<>*&^%").for(:subdomain) }
       it { should_not allow_value("12").for(:subdomain) } # < 3 digits
+    end
+  end
+
+  describe '#plan' do
+    let(:organisation) { FactoryBot.create(:organisation) }
+
+    let!(:other_plan) { FactoryBot.create(:plan, flat_fee_amount: Faker::Number.decimal(2)) }
+    let!(:other_subscription) { FactoryBot.create(:subscription,organisation: organisation, plan: other_plan, created_at: 10.days.ago) }
+    let!(:current_plan) { FactoryBot.create(:plan, flat_fee_amount: Faker::Number.decimal(2)) }
+    let!(:current_subscription) { FactoryBot.create(:subscription, organisation: organisation, plan: current_plan, created_at: Time.zone.now) }
+
+    it 'should be the plan associated with the most recently created subscription' do
+      expect(organisation.plan).to eq current_plan
     end
   end
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Plan, type: :model do
-  # describe 'associations' do
-  # end
+  describe 'associations' do
+    it { should have_many(:subscriptions) }
+  end
 
   describe 'validations' do
     context 'name' do


### PR DESCRIPTION
#### What's this PR do?
Adds subscription model to organisation and plan models

##### Background context
Part of the work to allow guests to make a payment to guides.

This work continues on from the work where subscriptions were added.This exposes subscriptions to organisations and plans in the app layerand associated test coverage.

Subsequent work will access the trip's organisation's plan to makea platform charge to our account when we handle the payment from aguest to a guide.

#### Where should the reviewer start?
//TODO: after rebase

#### How should this be manually tested?
n/a not plumbed in yet.

#### Screenshots
n/a

---

#### Migrations
Yes one. Please run:

`rails db:migrate`

#### Additional deployment instructions
none

#### Additional ENV Vars
none
