### PR TITLE
Extend bookings controller test coverage and handle invalid emails better.

### DIFF
--- a/app/controllers/public/trips/bookings_controller.rb
+++ b/app/controllers/public/trips/bookings_controller.rb
@@ -16,7 +16,7 @@ module Public
 
       # POST /bookings
       def create
-        @guest = Guest.find_or_create_by!(email: booking_params[:email])
+        @guest = Guest.find_or_create_by(email: booking_params[:email])
         @booking = @trip.bookings.new(booking_params.merge(guest: @guest))
 
         if @booking.save && create_charge


### PR DESCRIPTION
#### What's this PR do?
Do not throw an exception when calling Guest.find_or_create_by(...)
Extend bookings controller test coverage.

##### Background context
SimpleCov showed the request specs were missing a few conditional branches in the controller.

- Do not throw an exception when calling Guest.find_or_create_by(...)

...After adding specs covering the attempt to create a new booking (and guest) using an invalid email address, the exception thrown was causing an app error.

This uses Rails' buit in validation and controller response in a safer/ expected way


