### PR TITLE
Add currency field to both organisation and trip models.

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,7 @@
 class Organisation < ApplicationRecord
+  enum currency: %i[eur gbp usd]
+
+  validates :currency, presence: true
   validates :name, format: /\A[\sa-zA-Z0-9_.'\-]+\z/, allow_blank: false
   validates :stripe_account_id, format: /\A[a-zA-Z0-9_\-]{5,50}\z/, allow_blank: true
   validates :subdomain, format: /\A([a-zA-Z0-9][a-zA-Z0-9_\-]{3,30})\z/, allow_blank: true

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,4 +1,6 @@
 class Trip < ApplicationRecord
+  enum currency: %i[eur gbp usd]
+
   validate :start_date_before_end_date
   validates :name, format: /\A[\sa-zA-Z0-9_.\-]+\z/, presence: true # TODO: make this unique within an organisation's scope
   validates :minimum_number_of_guests,
@@ -24,5 +26,9 @@ class Trip < ApplicationRecord
     return if start_date <= end_date
 
     errors.add(:base, :start_date_after_end_date, message: 'start date must be before end date')
+  end
+
+  def currency
+    self[:currency] || organisation.currency
   end
 end

--- a/db/migrate/20190121174341_add_currency_to_organisation_and_trip.rb
+++ b/db/migrate/20190121174341_add_currency_to_organisation_and_trip.rb
@@ -1,0 +1,6 @@
+class AddCurrencyToOrganisationAndTrip < ActiveRecord::Migration[5.2]
+  def change
+    add_column :organisations, :currency, :integer
+    add_column :trips, :currency, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_20_131953) do
+ActiveRecord::Schema.define(version: 2019_01_21_174341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 2019_01_20_131953) do
     t.uuid "updated_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "currency"
   end
 
   create_table "plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -132,6 +133,7 @@ ActiveRecord::Schema.define(version: 2019_01_20_131953) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "organisation_id"
+    t.integer "currency"
     t.index ["organisation_id"], name: "index_trips_on_organisation_id"
   end
 

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :organisation do
     address { Faker::Address.full_address }
+    currency { %w[eur gbp usd].sample }
     name { Faker::Name.name }
     stripe_account_id { "acct_#{Faker::Bank.account_number(16)}" }
     subdomain { Faker::Internet.domain_word }

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,7 +1,7 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Organisation, type: :model do
-  describe 'associations' do
+  describe "associations" do
     it { should have_many(:guides).through(:organisation_memberships) }
     it { should have_many(:subscriptions) }
     it { should have_many(:trips) }
@@ -9,24 +9,26 @@ RSpec.describe Organisation, type: :model do
     # has_many: accomodation_providers
   end
 
-  describe 'validations' do
-    context 'name' do
+  describe "validations" do
+    it { should validate_presence_of(:currency) }
+
+    context "name" do
       it { should allow_value(Faker::Lorem.word).for(:name) }
-      it { should_not allow_value('<SQL INJECTION>').for(:name) }
+      it { should_not allow_value("<SQL INJECTION>").for(:name) }
     end
-    context 'stripe_account_id' do
+    context "stripe_account_id" do
       it { should allow_value("acct_#{Faker::Number.number(15)}").for(:stripe_account_id) }
       it { should_not allow_value("!<>*&^%").for(:stripe_account_id) }
     end
-    context 'subdomain' do
+    context "subdomain" do
       it { should allow_value(Faker::Internet.domain_word).for(:subdomain) }
-      it { should_not allow_value("-#{Faker::Internet.domain_word}").for(:subdomain) } # beginning with '-'
+      it { should_not allow_value("-#{Faker::Internet.domain_word}").for(:subdomain) } # beginning with "-"
       it { should_not allow_value("!<>*&^%").for(:subdomain) }
       it { should_not allow_value("12").for(:subdomain) } # < 3 digits
     end
   end
 
-  describe '#plan' do
+  describe "#plan" do
     let(:organisation) { FactoryBot.create(:organisation) }
 
     let!(:other_plan) { FactoryBot.create(:plan, flat_fee_amount: Faker::Number.decimal(2)) }
@@ -34,8 +36,10 @@ RSpec.describe Organisation, type: :model do
     let!(:current_plan) { FactoryBot.create(:plan, flat_fee_amount: Faker::Number.decimal(2)) }
     let!(:current_subscription) { FactoryBot.create(:subscription, organisation: organisation, plan: current_plan, created_at: Time.zone.now) }
 
-    it 'should be the plan associated with the most recently created subscription' do
+    it "should be the plan associated with the most recently created subscription" do
       expect(organisation.plan).to eq current_plan
     end
   end
+
+  it { should define_enum_for(:currency).with(%i[eur gbp usd]) }
 end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -1,36 +1,36 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Trip, type: :model do
-  describe 'associations' do
+  describe "associations" do
     it { should belong_to(:organisation) }
     it { should have_many(:bookings) }
     it { should have_many(:guests).through(:bookings) }
     it { should have_and_belong_to_many(:guides) }
   end
 
-  describe 'validations' do
-    describe 'name' do
-      it { should_not allow_value('<SQL INJECTION>').for(:name) }
+  describe "validations" do
+    describe "name" do
+      it { should_not allow_value("<SQL INJECTION>").for(:name) }
       it { should allow_value(Faker::Lorem.word).for(:name) }
       # TODO: check uniqueness to organisation scope
     end
 
-    describe 'minimum_number_of_guests' do
+    describe "minimum_number_of_guests" do
       it { should validate_numericality_of(:minimum_number_of_guests).only_integer }
     end
 
-    describe 'maximum_number_of_guests' do
+    describe "maximum_number_of_guests" do
       it { should validate_numericality_of(:maximum_number_of_guests).only_integer }
     end
 
-    # TODO: when know format of date string we're sending back and also test that
-    describe 'dates' do
+    # TODO: when know format of date string we"re sending back and also test that
+    describe "dates" do
       subject { trip.valid? }
 
       let(:trip) { FactoryBot.build(:trip, start_date: start_date, end_date: end_date) }
 
-      context 'valid' do
-        context 'start_date is before end_date' do
+      context "valid" do
+        context "start_date is before end_date" do
           let(:start_date) { Date.today }
           let(:end_date) { Faker::Date.between(2.days.from_now, 10.days.from_now) }
 
@@ -38,13 +38,36 @@ RSpec.describe Trip, type: :model do
         end
       end
 
-      context 'invalid' do
-        context 'start_date is after end_date' do
+      context "invalid" do
+        context "start_date is after end_date" do
           let(:start_date) { Faker::Date.between(2.days.from_now, 10.days.from_now) }
           let(:end_date) { Date.today }
 
           it { should be false }
         end
+      end
+    end
+  end
+
+  it { should define_enum_for(:currency).with(%i[eur gbp usd]) }
+
+  describe "#currency" do
+    subject { described_class.new(attributes).currency }
+    let(:organisation) { FactoryBot.create(:organisation, currency: "usd") }
+
+    context "when the trip has not had a currency set" do
+      let(:attributes) { { organisation: organisation } }
+
+      it "should be overriden by the organisation's currency" do
+        expect(subject).to eq("usd")
+      end
+    end
+
+    context "when the trip has had a currency set" do
+      let(:attributes) { { currency: :gbp, organisation: organisation } }
+
+      it "should be the trip specific currency" do
+        expect(subject).to eq("gbp")
       end
     end
   end


### PR DESCRIPTION
#### What's this PR do?
Adds currency field to both organisation and trip models.
Minor coding standards to touched files.

##### Background context
Part of the work to add real data throughout the app/ to models. Instead of having hard coded fake data.

If a trip has not had a currency set it will use its organisations currency.


#### Where should the reviewer start?
db/* - has the migrations and change in schema.rb
app/models/* - has the currency expressed as an enum
app/models/trip#currency - is the only non-standard part of the code: which overrides the enum value, using the trip's organisation's currency value (which has to have a currency value) if there isn't a currency set for the trip.

This pattern will be reused, ie: when there isn't a trip-specific value, default to the organisation's value.

#### How should this be manually tested?
n/a - not really in the UX yet.

#### Screenshots
n/a

---

#### Migrations
yes - will need to run:

`rails db:migrate`

#### Additional deployment instructions
none

#### Additional ENV Vars
none
