### PR TITLE
Allow first_name and last_name as permitted params for the booking resource.

### DIFF
--- a/app/controllers/public/trips/bookings_controller.rb
+++ b/app/controllers/public/trips/bookings_controller.rb
@@ -43,7 +43,7 @@ module Public
       private
 
       def booking_params
-        params.require(:booking).permit(:email)
+        params.require(:booking).permit(:email, :first_name, :last_name)
       end
 
       def check_timeout

--- a/spec/requests/public/trips/bookings_controller_spec.rb
+++ b/spec/requests/public/trips/bookings_controller_spec.rb
@@ -17,10 +17,18 @@ RSpec.describe "Public::Trips::BookingsController", type: :request do
 
   describe "#create POST /public/trips/:trip_id/bookings" do
     let(:booking) { Booking.last }
+    let!(:email) { Faker::Internet.email }
+    let(:first_name) { Faker::Name.first_name }
+    let(:last_name) { Faker::Name.last_name }
     let!(:trip) { FactoryBot.create(:trip) }
-    let(:params) do
+    let!(:params) do
       {
-        booking: { email: email },
+        booking:
+        {
+          email: email,
+          first_name: first_name,
+          last_name: last_name
+        },
         stripeToken: "tok_#{Faker::Crypto.md5}"
       }
     end
@@ -55,6 +63,10 @@ RSpec.describe "Public::Trips::BookingsController", type: :request do
           expect(trip.reload.bookings).to include booking
           expect(booking.guest).to eq guest
           expect(trip.guests).to include guest
+
+          expect(booking.email).to eq params[:booking][:email]
+          expect(booking.first_name).to eq params[:booking][:first_name]
+          expect(booking.last_name).to eq params[:booking][:last_name]
 
           expect(response.code).to eq "302"
           expect(response).to redirect_to(edit_public_booking_path(booking))


### PR DESCRIPTION
#### What's this PR do?
Allow first_name and last_name as permitted params for the booking resource.
And cover this in the controller spec.

##### Background context
Part of the work to allow real data to be used when a user creates a booking.

We want to be able to save the data that users enter on the booking.

Follow up work will include further data users will enter: address, dietary requirements, etc.

Once a guest's email address has been confirmed, then we can prepopulate the guest edit form with details from the booking, allowing the guest to confirm, or edit, the details from the booking and copy them over to the guest model proper.

#### Where should the reviewer start?
app/controllers/public/trips/bookings_controller.rb - the only app layer changes.

#### How should this be manually tested?
We're not surfacing this data back to the user yet.. so can't really manually test this.

#### Screenshots
n/a

---

#### Migrations
none

#### Additional deployment instructions
none

#### Additional ENV Vars
none
