### PR TITLE
Add description, full_cost and deposit_cost fields to trips.

### DIFF
--- a/db/migrate/20190122052609_add_description_full_cost_deposit_cost_to_trips.rb
+++ b/db/migrate/20190122052609_add_description_full_cost_deposit_cost_to_trips.rb
@@ -1,0 +1,7 @@
+class AddDescriptionFullCostDepositCostToTrips < ActiveRecord::Migration[5.2]
+  def change
+    add_column :trips, :description, :text
+    add_column :trips, :full_cost, :float
+    add_column :trips, :deposit_cost, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_21_174341) do
+ActiveRecord::Schema.define(version: 2019_01_22_052609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -134,6 +134,9 @@ ActiveRecord::Schema.define(version: 2019_01_21_174341) do
     t.datetime "updated_at", null: false
     t.uuid "organisation_id"
     t.integer "currency"
+    t.text "description"
+    t.float "full_cost"
+    t.float "deposit_cost"
     t.index ["organisation_id"], name: "index_trips_on_organisation_id"
   end
 


### PR DESCRIPTION
#### What's this PR do?
Adds description, full_cost and deposit_cost fields to trips.

##### Background context
Part of the work to replace hard coded data with real data.

This will be visible to users in the new booking view. Follow up work will expose this in the relevant views.

The deposit_cost will not be used yet but it makes sense to add it in this commit.

#### Where should the reviewer start?
db/*

#### How should this be manually tested?
Not exposed yet in the app or view layers.

#### Screenshots
n/a

---

#### Migrations
Yes, run:

`rails db:migrate`

#### Additional deployment instructions
none

#### Additional ENV Vars
none
