### PR TITLE
Add currency and cost caluculator service models

### DIFF
--- a/app/services/bookings/cost_calculator.rb
+++ b/app/services/bookings/cost_calculator.rb
@@ -1,0 +1,33 @@
+module Bookings
+  # Handles time sensitive costs due based on trip deposit cost, full cost,
+  # proximity to trip start date, etc.
+  class CostCalculator
+    def initialize(booking)
+      @booking = booking
+    end
+
+    def amount_due_in_cents
+      (amount_due * 100).to_i
+    end
+
+    def amount_due
+      calculate_amount_due
+    end
+
+    private
+
+    def calculate_amount_due
+      @booking.full_cost
+      # TODO:
+      # At some point this will need to know
+      # if to make a payment that is the deposit,
+      # or the full payment. Will need to create
+      # a customer for this, ie: to make one charge
+      # now (deposit) and another full amount later.
+      # Ref: https://stripe.com/docs/saving-cards
+      # Then once the full payment has been made - delete the users’ card data
+      # Safest thing to do here.
+      # TODO: Need to be careful if we ever handle JPY (a zero-decimal currency)
+    end
+  end
+end

--- a/app/services/currency.rb
+++ b/app/services/currency.rb
@@ -1,0 +1,5 @@
+class Currency
+  def self.iso_to_symbol(iso)
+    { "eur": "€", "gbp": "£", "usd": "$" }.fetch(iso.to_sym)
+  end
+end

--- a/spec/services/bookings/cost_calculator_spec.rb
+++ b/spec/services/bookings/cost_calculator_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Bookings::CostCalculator, type: :model do
+  let(:booking) { FactoryBot.create(:booking, trip: trip) }
+  let(:trip) { FactoryBot.create(:trip, currency: :gbp, full_cost: 500) }
+
+  describe "#amount_due" do
+    subject(:amount_due) { described_class.new(booking).amount_due }
+
+    context "valid and successful" do
+      it { should eq 500 }
+    end
+  end
+
+  describe "#amount_due_in_cents" do
+    subject(:amount_due_in_cents) do
+      described_class.new(booking).amount_due_in_cents
+    end
+
+    context "valid and successful" do
+      it { should eq 50_000 }
+    end
+  end
+end

--- a/spec/services/currency_spec.rb
+++ b/spec/services/currency_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Currency, type: :model do
+  describe "#iso_to_symbol" do
+    subject(:iso_to_symbol) { described_class.iso_to_symbol(iso) }
+
+    context "valid and successful" do
+      let!(:iso) { %i[eur gbp usd].sample }
+      let(:expected_symbol) { { eur: "€", gbp: "£", usd: "$" }.fetch(iso) }
+
+      it "should return the correct currency symbol" do
+        expect(iso_to_symbol).to eq expected_symbol
+      end
+    end
+
+    context "a currency symbol that does not exist" do
+      let!(:iso) { Faker::Lorem.word }
+
+      it "should throw a KeyError" do
+        expect{ iso_to_symbol }.to raise_error(KeyError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
Adds new service models: Currency and Bookings::CostCalculator.


##### Background context
Part of the work to allow using real trip data in the payment process.

Follow up work will incorporate these models into the actual implementation.

#### Where should the reviewer start?
There's two code files and two spec files covering them... easy...

#### How should this be manually tested?
n/a  - not plumbed in yet.

#### Screenshots
n/a

---

#### Migrations
none

#### Additional deployment instructions
none


#### Additional ENV Vars
none

