### PR TITLE
Use guide's name and email address in from and reply-to fields when sending out new booking email to guest.

### DIFF
--- a/app/mailers/guest_booking_mailer.rb
+++ b/app/mailers/guest_booking_mailer.rb
@@ -4,8 +4,8 @@ class GuestBookingMailer < ApplicationMailer
     @booking = params[:booking]
 
     mail(to: @booking.email,
-         # TODO: from: "#{@booking.guide_name} <#{@booking.owner_email}>",
-         # TODO: reply_to: "#{@booking.owner_name} <#{@booking.owner_email}>"
+         from: "#{@booking.guide_name} <#{@booking.guide_email}>",
+         reply_to: "#{@booking.guide_name} <#{@booking.guide_email}>",
          subject: "Successful booking for #{@booking.trip_name}")
   end
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -5,7 +5,9 @@ class Booking < ApplicationRecord
   belongs_to :trip
   belongs_to :guest, optional: true
 
-  delegate :currency, :deposit_cost, :full_cost,
+  delegate :name, :email, to: :guide, prefix: true
+
+  delegate :currency, :deposit_cost, :full_cost, :guide,
            :organisation_name, :start_date, :end_date, to: :trip
   delegate :description, :maximum_number_of_guests, :name,
            :guest_count, to: :trip, prefix: true

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -11,6 +11,10 @@ class Organisation < ApplicationRecord
   has_many :subscriptions
   has_many :trips
 
+  def owner
+    organisation_memberships.owners&.first&.guide
+  end
+
   def plan
     current_subscription&.plan
   end

--- a/app/models/organisation_membership.rb
+++ b/app/models/organisation_membership.rb
@@ -3,4 +3,6 @@ class OrganisationMembership < ApplicationRecord
   belongs_to :guide
 
   validates_uniqueness_of :guide, scope: :organisation
+
+  scope :owners, -> { where(owner: true) }
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -16,8 +16,13 @@ class Trip < ApplicationRecord
   has_many :bookings
   has_many :guests, through: :bookings
   has_and_belongs_to_many :guides
+  has_many :organisation_memberships, through: :guides
 
   delegate :name, to: :organisation, prefix: true
+
+  def guide
+    organisation_memberships.owners&.first&.guide
+  end
 
   def guest_count
     # TODO: need to look into this...

--- a/spec/mailers/guest_booking_mailer_spec.rb
+++ b/spec/mailers/guest_booking_mailer_spec.rb
@@ -2,15 +2,26 @@ require "rails_helper"
 
 RSpec.describe GuestBookingMailer, type: :mailer do
   describe "#new" do
-    let(:booking) { FactoryBot.create(:booking) }
-    let(:mail) do 
-      described_class.with(booking: booking).new.deliver_now
+    let!(:booking) { FactoryBot.create(:booking, trip: trip) }
+    let!(:guide) { FactoryBot.create(:guide, email: guide_email, name: guide_name) }
+    let!(:guide_email) { Faker::Internet.email }
+    let!(:guide_name) { Faker::Name.name }
+    let(:mail) { described_class.with(booking: booking).new.deliver_now }
+    let(:organisation) { FactoryBot.create(:organisation) }
+    let!(:organisation_membership) do
+      FactoryBot.create(:organisation_membership,
+                        guide: guide,
+                        organisation: organisation,
+                        owner: true)
     end
+    let!(:trip) { FactoryBot.create(:trip, guides: [guide]) }
 
     it "renders the headers" do
       expect(mail.subject).to eq("Successful booking for #{booking.trip_name}")
       expect(mail.to).to eq([booking.email])
-      expect(mail.from).to eq(["bookings@bookyour.place"])
+      # Isn't picking up the actual format used in mailer - with guide's name, etc.
+      expect(mail.from).to eq([guide_email])
+      expect(mail.reply_to).to eq([guide_email])
     end
 
     it "renders the body" do


### PR DESCRIPTION
#### What's this PR do?
Use guide's name and email address in from and reply-to fields when sending out new booking email to guest.

##### Background context
Follow up work from the initial getting email functionality added to the app.

This will make sure the new booking/guest doesn't receive an email from bookings@bookyour.place but rather from guide_name <guide@guidedomain.com>.

This is the kind of white labelling we want for our guides.

Follow up work will need to make sure that guides_trips joins get created when a trip is created... else none of these references/associations will work.

#### Where should the reviewer start?
The real change in functionality is in: app/mailers/guest_booking_mailer.rb
The changes in the models are mostly taking care of getting scopes and associations between models so that booking.guide is available when the email is sent.


#### How should this be manually tested?
n/a - not really plumbed in yet

#### Screenshots
n/a

---

#### Migrations
none

#### Additional deployment instructions
none

#### Additional ENV Vars
none
