### PR TITLE
Tighten up GuestController actions and add sign_in / sign_out spec helpers.

### DIFF
--- a/app/controllers/guests_controller.rb
+++ b/app/controllers/guests_controller.rb
@@ -1,38 +1,17 @@
 class GuestsController < ApplicationController
-  before_action :set_guest, only: [:show, :edit, :update, :destroy]
+  before_action :set_guest, only: %i[show edit update]
+  before_action :authenticate_guest!
 
-  # GET /guests
-  def index
-    # TODO: scope this to an organisation
-    @guests = Guest.all
-  end
+  def edit; end
 
-  # GET /guests/1
-  def show
-  end
+  def show; end
 
-  # GET /guests/new
-  def new
-    @guest = Guest.new
-  end
-
-  # GET /guests/1/edit
-  def edit
-  end
-
-  # POST /guests
   # TODO: This is overridden by Devise::RegistrationsController#create
+  # But we actually want to override that behaviour... we want to only create
+  # a guest when a new booking clicks on the link in their email.
   # def create
-  #   @guest = Guest.new(guest_params)
-
-  #   if @guest.save
-  #     redirect_to @guest, notice: 'Guest was successfully created.'
-  #   else
-  #     render :new
-  #   end
   # end
 
-  # PATCH/PUT /guests/1
   def update
     if @guest.update(guest_params)
       redirect_to @guest, notice: 'Guest was successfully updated.'
@@ -41,24 +20,15 @@ class GuestsController < ApplicationController
     end
   end
 
-  # DELETE /guests/1
-  def destroy
-    #TODO: what do we want to happen here? Just remove a guest from an organisation?
-    # Destroy organisation_guest join?
-    @guest.destroy
-    redirect_to guests_url, notice: 'Guest was successfully destroyed.'
-  end
-
   private
-  # Use callbacks to share common setup or constraints between actions.
+
   def set_guest
-    # TODO: scope this to an organisation
-    @guest = Guest.find(params[:id])
+    @guest = current_guest
   end
 
-  # Only allow a trusted parameter "white list" through.
   def guest_params
     params.require(:guest).permit(:address,
+                                  # TODO: we want to email new & old emails to let them know of change
                                   :email,
                                   :name,
                                   :phone_number)

--- a/app/views/guests/edit.html.erb
+++ b/app/views/guests/edit.html.erb
@@ -2,5 +2,4 @@
 
 <%= render 'form', guest: @guest %>
 
-<%= link_to 'Show', @guest %> |
-<%= link_to 'Back', guests_path %>
+<%= link_to 'Show', @guest %>

--- a/app/views/guests/show.html.erb
+++ b/app/views/guests/show.html.erb
@@ -1,4 +1,3 @@
 <p id="notice"><%= notice %></p>
-
-<%= link_to 'Edit', edit_guest_path(@guest) %> |
-<%= link_to 'Back', guests_path %>
+<%= @guest.name %>
+<%= link_to 'Edit', edit_guest_path(@guest) %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,6 +61,8 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include Devise::Test::IntegrationHelpers, type: :request
+
+  config.include RequestSpecHelper, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/guests_controller_spec.rb
+++ b/spec/requests/guests_controller_spec.rb
@@ -1,173 +1,120 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'GuestsController', type: :request do
-  # TODO: ** implement created_by and updated_by and test them here
+RSpec.describe "GuestsController", type: :request do
+  let(:resource_sign_in_path) { new_guest_session_path }
 
-  describe '#create POST /guests' do
-    # TODO: this is overridden by Devise::RegistrationsController#create
-    # Need to make other route to allow a guide to add/ create a guest...
-    # include_examples 'authentication'
-
-    # TODO: need to test the sign up path rather than directly creating a guest
-    # Only guests can create themselves? By signing up?
-
-    def do_request(url: "/guests", params: {})
-      post url, params: params
-    end
-
-    context 'valid and successful' do
-      let(:guest) { Guest.last }
-      let!(:params) do
-        { guest: 
-          {
-            address: Faker::Address.full_address,
-            email: Faker::Internet.email,
-            name: Faker::Name.name,
-            phone_number: Faker::PhoneNumber.cell_phone
-          }
-        }
-      end
-
-      it 'should create a new guest' do
-        pending 'Need to think about how guests are created: when they sign up to a trip, and when a guide adds them to a trip, etc'
-        expect { do_request(params: params) }.to change { Guest.count }.by(1)
-
-        expect(response.code).to eq '302'
-        expect(response).to redirect_to(guest_path(guest))
-
-        expect(guest.address).to eq params[:guest][:address]
-        expect(guest.email).to eq params[:guest][:email]
-        expect(guest.name).to eq params[:guest][:name]
-        expect(guest.phone_number).to eq params[:guest][:phone_number]
-
-        # TODO: ** expect(guest.created_by).to eq user
-        # TODO: ** expect(guest.updated_by).to eq user
-      end
-    end
-  end
-
-  describe '#edit GET /guests/:id/edit' do
-    include_examples 'authentication'
-
-    # TODO: who can do this? A user can update their own details - need to scope this to current_user
-    # A guide can edit a guests' organisation_membership but not the user details (email, etc).
-    # Need to test that a guest / guide / public access - can not access this guest's edit page.
-    # Need to scope so that only the current logged in user can update their own details.
-    # Revisit when Devise is installed
+  describe "#edit GET /guests/:id/edit" do
+    include_examples "authentication"
 
     let(:guest) { FactoryBot.create(:guest) }
 
+    # TODO: Need to include tests for 1 time only token in the booking-to-guest email
     def do_request(url: "/guests/#{guest.id}/edit", params: {})
       get url, params: params
     end
 
-    context 'valid and successful' do
-      it 'should successfully render' do
-        pending 'Need to make sure that only a signed in user can edit their OWN details, and that a guide can edit a users guest_trip details, etc'
-        do_request
+    context "signed in" do
+      before { sign_in(guest) }
 
-        expect(response).to be_successful
+      context "valid and successful" do
+        it "should successfully render" do
+          do_request
+
+          expect(response).to be_successful
+        end
       end
     end
   end
 
-  describe '#index get /guests' do
-    include_examples 'authentication'
+  describe "#show get /guests/:id" do
+    include_examples "authentication"
 
-    # TODO: need to scope this to an organisation?
-    # Test that current_user is organsation owner and they can only access their own organisation's users
-    # All other cases, redirect to home page
-    # Revisit when Devise is installed
-    def do_request(url: "/guests/", params: {})
-      get url, params: params
-    end
-
-    context 'valid and successful' do
-      it 'should successfully render' do
-        pending 'see notes above'
-        do_request
-
-        expect(response).to be_successful
-      end
-    end
-  end
-
-  describe '#new get /guests/new' do
-    include_examples 'authentication'
-
-    # TODO: This is the sign up page? Or is the creation of new guests done in the background
-    # when a guest clicks on a guide's link to join a trip?
-    # Revisit when Devise is installed
-    def do_request(url: "//guests/new", params: {})
-      get url, params: params
-    end
-
-    it 'should successfully render' do
-      pending 'see notes above'
-      do_request
-
-      expect(response).to be_successful
-    end
-  end
-
-  describe '#show get /guests/:id' do
-    include_examples 'authentication'
-
-    # TODO: Need to scope this to either a user, who can view ONLY their own details
-    # OR: a guide who has a guest associated with their organisation
-    # Revisit when Devise is installed
-    let(:guest) { FactoryBot.create(:guest) }
+    let!(:guest) { FactoryBot.create(:guest) }
 
     def do_request(url: "/guests/#{guest.id}", params: {})
       get url, params: params
     end
 
-    context 'valid and successful' do
-      it 'should successfully render' do
-        pending 'see notes above'
-        do_request
+    context "signed in" do
+      before { sign_in(guest) }
 
-        expect(response).to be_successful
+      context "valid and successful" do
+        it "should successfully render" do
+          do_request
+
+          expect(response).to be_successful
+        end
+
+        context "another guest" do
+          let!(:other_guest) { FactoryBot.create(:guest) }
+
+          it "should not be visible to another guide" do
+            sign_out(guest)
+            sign_in(other_guest)
+
+            do_request
+
+            expect(response).to be_successful
+            expect(response.body).to include(other_guest.name)
+            expect(response.body).to_not include(guest.name)
+            # And redirect_to?
+          end
+        end
       end
     end
   end
 
-  describe '#update PATCH /guests/:id' do
-    include_examples 'authentication'
+  describe "#update PATCH /guests/:id" do
+    include_examples "authentication"
 
-    # Need to scope so that only the current logged in user can update their own details.
-    # An organisation owner, can update a user's other details, via their organisation_membership
-    # Revist when Devise is installed
     let!(:guest) { FactoryBot.create(:guest) }
 
     def do_request(url: "/guests/#{guest.id}", params: {})
       patch url, params: params
     end
 
-    context 'valid and successful' do
-      let(:params) { 
-        {
-          guest: {
-            address: Faker::Address.full_address,
-            email: Faker::Internet.email,
-            name: Faker::Name.name,
-            phone_number: Faker::PhoneNumber.cell_phone
-          }
-        } 
-      }
+    context "signed in" do
+      before { sign_in(guest) }
 
-      it 'should update the guest' do
-        pending 'See notes above'
-        do_request(params: params)
+      context "valid and successful" do
+        let!(:params) { 
+          {
+            guest: {
+              address: Faker::Address.full_address,
+              email: Faker::Internet.email,
+              name: Faker::Name.name,
+              phone_number: Faker::PhoneNumber.cell_phone
+            }
+          } 
+        }
 
-        guest.reload
+        it "should update the guest" do
+          do_request(params: params)
 
-        expect(guest.address).to eq params[:guest][:address]
-        expect(guest.email).to eq params[:guest][:email]
-        expect(guest.name).to eq params[:guest][:name]
-        expect(guest.phone_number).to eq params[:guest][:phone_number]
+          guest.reload
 
-        # TODO: ** expect(guest.updated_by).to eq user
+          expect(guest.address).to eq params[:guest][:address]
+          expect(guest.email).to eq params[:guest][:email]
+          expect(guest.name).to eq params[:guest][:name]
+          expect(guest.phone_number).to eq params[:guest][:phone_number]
+
+          # TODO: ** expect(guest.updated_by).to eq user
+        end
+      end
+
+      context "invalid and unsuccessful" do
+        # TODO: should we allow guests to update their emails this easily?
+        let!(:params) { { guest: { email: nil } } }
+
+        it "should update the guest" do
+          do_request(params: params)
+
+          expect(response.status).to eq(200)
+
+          expect(guest.reload.email).to_not be_nil
+
+          # TODO: ** expect(guest.updated_by).to eq user
+        end
       end
     end
   end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,0 +1,22 @@
+module RequestSpecHelper
+  include Warden::Test::Helpers
+
+  def self.included(base)
+    base.before(:each) { Warden.test_mode! }
+    base.after(:each) { Warden.test_reset! }
+  end
+
+  def sign_in(resource)
+    login_as(resource, scope: warden_scope(resource))
+  end
+
+  def sign_out(resource)
+    logout(warden_scope(resource))
+  end
+
+  private
+
+  def warden_scope(resource)
+    resource.class.name.underscore.to_sym
+  end
+end

--- a/spec/support/shared_examples/authentication.rb
+++ b/spec/support/shared_examples/authentication.rb
@@ -1,9 +1,17 @@
-RSpec.shared_examples 'authentication' do
-  context 'not signed in' do
-    it 'should redirect to the sign in page' do
+RSpec.shared_examples "authentication" do
+  context "not signed in" do
+    it "should redirect to the sign in page" do
       do_request
 
-      expect(response).to redirect_to(new_guide_session_path)
+      expect(response).to redirect_to(sign_in_path)
+    end
+  end
+
+  def sign_in_path
+    if defined? resource_sign_in_path
+      resource_sign_in_path
+    else
+      new_guide_session_path
     end
   end
 end


### PR DESCRIPTION
#### What's this PR do?
Tightens up (reducing unused actions and require authentication) GuestController actions and add sign_in / sign_out spec helpers.

##### Background context
This work reduces the actions in the GuestController to those we have to have to increase security and prevent any destructive behaviour.

Part of the work separating the guest and guide routes.

Calls the Devise authentication method authenticate_guest! on all guest routes, so a guest has to log in to visit their data.

Follow up work will add a one-time-only token-based log in URL, which will be emailed to the email address in every new booking. Which, when clicked creates a new guest (from the booking data).


#### Where should the reviewer start?
app/controllers/guests_controller.rb
 ... this has the main tidying up of code, the rest is specs, spec helpers/config (allowing signing in/out in request specs) and small amendments to the guest views in:
app/views/guests/*
... which was removing links to guests#index which no longer exists for guests (a signed in guest, can not see ALL guests).

#### How should this be manually tested?
Bit hard, as guests are created when there's a new booking, using that email.
Wait until this batch of work is finished (with a background job sending email to new guest, etc) for full QA.

#### Screenshots
n/a

---

#### Migrations
none

#### Additional deployment instructions
none

#### Additional ENV Vars
none
