### PR TITLE
Define the routes that guests and guides are directed to after they log in/ log out.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,17 @@
 class ApplicationController < ActionController::Base
+  def after_sign_in_path_for(resource)
+    if resource.instance_of? Guide
+      guides_trips_path
+    elsif resource.instance_of? Guest
+      guests_trips_path
+    end
+  end
+
+  def after_sign_out_path_for(resource)
+    if resource == :guide
+      new_guide_session_path
+    elsif resource == :guest
+      new_guest_session_path
+    end
+  end
 end

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe "SessionsController", type: :request do
+  context "signing in" do
+    context "guests" do
+      describe "#create POST /guests/sign_in" do
+        let!(:guest) { FactoryBot.create(:guest) }
+        let!(:params) { { guest: { email: guest.email, password: guest.password } } }
+
+        def do_request(url: "/guests/sign_in", params: {})
+          post url, params: params
+        end
+
+        it "redirects to the guest page" do
+          do_request(params: params)
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to(guests_trips_path)
+        end
+      end
+    end
+
+    context "guides" do
+      describe "#create POST /guides/sign_in" do
+        let!(:guide) { FactoryBot.create(:guide) }
+        let!(:params) { { guide: { email: guide.email, password: guide.password } } }
+
+        def do_request(url: "/guides/sign_in", params: {})
+          post url, params: params
+        end
+
+        it "redirects to the guest page" do
+          do_request(params: params)
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to(guides_trips_path)
+        end
+      end
+    end
+  end
+
+  context "signing out" do
+    context "guests" do
+      describe "#destroy DELETE /guests/sign_out" do
+        let!(:guest) { FactoryBot.create(:guest) }
+
+        before { sign_in(guest) }
+
+        def do_request(url: "/guests/sign_out", params: {})
+          delete url, params: params
+        end
+
+        it "redirects to the guest page" do
+          do_request
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to(new_guest_session_path)
+        end
+      end
+    end
+
+    context "guides" do
+      describe "#destroy DELETE /guides/sign_out" do
+        let!(:guide) { FactoryBot.create(:guide) }
+
+        before { sign_in(guide) }
+
+        def do_request(url: "/guides/sign_out", params: {})
+          delete url, params: params
+        end
+
+        it "redirects to the guest page" do
+          do_request
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to(new_guide_session_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
Defines the routes that guests and guides are directed to after they log in/ log out.

##### Background context
Following on from the work that separated out all guests and guide routes, this work fixes the routing when guides or guests log in or out.

Previously, they would always be redirected to the generic log in page, when logging in or out, which would be the guest log in page, due to its primary order in the routes file, but now guests and guides are kept within their respective namespaces and are directed to trips#index after logging in and guests/ guides /sign_in when logged out.

Refs:
https://github.com/Book-Your-Place/bookyourplace/pull/93
https://github.com/Book-Your-Place/bookyourplace/pull/93/commits/a68fe00e8b762290115da786a1e4ae8bc2ced387

#### Where should the reviewer start?
app/controllers/application_controller.rb

#### How should this be manually tested?
After creating a guest or guide, go to guests/sign_in or guides/sign_in and take it from there.
You should be redirected to your /trips#index view.

Then hit sign out. You should be redirected to the guests / guides sign_in page.

Follow up work will build out the guests/trips#index view for guests - not needed for a while.

#### Screenshots
These are in order of a guide signing in:

![image](https://user-images.githubusercontent.com/1453680/51963904-d9bacd00-245c-11e9-846c-f6c575c83ac0.png)


![image](https://user-images.githubusercontent.com/1453680/51963914-dfb0ae00-245c-11e9-90ef-b5ca78691c58.png)


Now signing out...

![image](https://user-images.githubusercontent.com/1453680/51963926-e9d2ac80-245c-11e9-916a-8e3e63ba551d.png)


![image](https://user-images.githubusercontent.com/1453680/51963934-efc88d80-245c-11e9-9782-adca0e64ebc7.png)


---

#### Migrations
None

#### Additional deployment instructions
None

#### Additional ENV Vars
None
